### PR TITLE
MediaType.get(s) -> s.toMediaType()

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
   implementation(libs.mavericks.compose)
   implementation(libs.navigation.compose.core)
   implementation(libs.navigation.compose.ktx)
+  implementation(libs.okhttp)
   implementation(libs.retrofit.core)
   implementation(libs.retrofit.serialization)
 

--- a/android/app/src/main/kotlin/com/emergetools/hackernews/network/HNApi.kt
+++ b/android/app/src/main/kotlin/com/emergetools/hackernews/network/HNApi.kt
@@ -3,7 +3,7 @@ package com.emergetools.hackernews.network
 import com.emergetools.hackernews.network.models.Item
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -12,7 +12,7 @@ private const val HN_BASE_URL = "https://hacker-news.firebaseio.com/v0/"
 
 private val retrofit = Retrofit.Builder()
   .baseUrl(HN_BASE_URL)
-  .addConverterFactory(Json.asConverterFactory(MediaType.get("application/json")))
+  .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
   .build()
 
 interface HNApiService {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlin = "1.9.10"
 ksp = "1.9.10-1.0.13"
 material-compose = "1.6.3"
 navigation-compose = "2.7.7"
+okhttp = "4.11.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -58,5 +59,8 @@ mavericks-compose = "com.airbnb.android:mavericks-compose:2.7.0"
 navigation-compose-core = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 navigation-compose-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigation-compose" }
 
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+
 retrofit-core = "com.squareup.retrofit2:retrofit:2.9.0"
 retrofit-serialization = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
+


### PR DESCRIPTION
OkHttp 4 moves MediaType.get to toMediaType (an extension function) See: https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/

@rbro112: could we chat about this quickly at some point? I needed to tweak this to get hn to build recently but I'm not clear on where the version of okhttp is chosen.