### PR TITLE
Remove AndroidManifest.xml package

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.emergetools.hackernews">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
     android:name="com.emergetools.hackernews.HNApplication"


### PR DESCRIPTION
Previously we got the following log message:
> Task :app:processDebugMainManifest
package="com.emergetools.hackernews" found in source AndroidManifest.xml: /Users/chromy/src/hackernews/android/app/src/main/AndroidManifest.xml. Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored. Recommendation: remove package="com.emergetools.hackernews" from the source AndroidManifest.xml: /Users/chromy/src/hackernews/android/app/src/main/AndroidManifest.xml.