### PR TITLE
Feed Loading Strategy

### DIFF
--- a/android/app/src/main/java/com/emergetools/HackerNewsApplication.kt
+++ b/android/app/src/main/java/com/emergetools/HackerNewsApplication.kt
@@ -2,8 +2,9 @@ package com.emergetools
 
 import android.app.Application
 import android.content.Context
-import com.emergetools.hackernews.data.HackerNewsBaseClient
+import com.emergetools.hackernews.data.HackerNewsBaseDataSource
 import com.emergetools.hackernews.data.HackerNewsSearchClient
+import com.emergetools.hackernews.data.ItemRepository
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import java.time.Duration
@@ -14,12 +15,13 @@ class HackerNewsApplication: Application() {
     .readTimeout(Duration.ofSeconds(30))
     .build()
 
-  val baseClient = HackerNewsBaseClient(json, httpClient)
+  private val baseClient = HackerNewsBaseDataSource(json, httpClient)
   val searchClient = HackerNewsSearchClient(json, httpClient)
+  val itemRepository = ItemRepository(baseClient)
 }
 
-fun Context.baseClient(): HackerNewsBaseClient {
-  return (this.applicationContext as HackerNewsApplication).baseClient
+fun Context.itemRepository(): ItemRepository {
+  return (this.applicationContext as HackerNewsApplication).itemRepository
 }
 
 fun Context.searchClient(): HackerNewsSearchClient {

--- a/android/app/src/main/java/com/emergetools/HackerNewsApplication.kt
+++ b/android/app/src/main/java/com/emergetools/HackerNewsApplication.kt
@@ -5,12 +5,17 @@ import android.content.Context
 import com.emergetools.hackernews.data.HackerNewsBaseClient
 import com.emergetools.hackernews.data.HackerNewsSearchClient
 import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import java.time.Duration
 
 class HackerNewsApplication: Application() {
   private val json = Json { ignoreUnknownKeys = true }
+  private val httpClient = OkHttpClient.Builder()
+    .readTimeout(Duration.ofSeconds(30))
+    .build()
 
-  val baseClient = HackerNewsBaseClient(json)
-  val searchClient = HackerNewsSearchClient(json)
+  val baseClient = HackerNewsBaseClient(json, httpClient)
+  val searchClient = HackerNewsSearchClient(json, httpClient)
 }
 
 fun Context.baseClient(): HackerNewsBaseClient {

--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseClient.kt
@@ -3,6 +3,7 @@ package com.emergetools.hackernews.data
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.GET
@@ -34,10 +35,11 @@ interface HackerNewsBaseApi {
   suspend fun getItem(@Path("id") itemId: Long): Item
 }
 
-class HackerNewsBaseClient(json: Json) {
+class HackerNewsBaseClient(json: Json, client: OkHttpClient) {
   private val retrofit = Retrofit.Builder()
     .baseUrl(BASE_FIREBASE_URL)
     .addConverterFactory(json.asConverterFactory("application/json; charset=UTF8".toMediaType()))
+    .client(client)
     .build()
 
   val api = retrofit.create(HackerNewsBaseApi::class.java)

--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
@@ -35,7 +35,7 @@ interface HackerNewsBaseApi {
   suspend fun getItem(@Path("id") itemId: Long): Item
 }
 
-class HackerNewsBaseClient(json: Json, client: OkHttpClient) {
+class HackerNewsBaseDataSource(json: Json, client: OkHttpClient) {
   private val retrofit = Retrofit.Builder()
     .baseUrl(BASE_FIREBASE_URL)
     .addConverterFactory(json.asConverterFactory("application/json; charset=UTF8".toMediaType()))

--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsSearchClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsSearchClient.kt
@@ -3,6 +3,7 @@ package com.emergetools.hackernews.data
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.GET
@@ -26,10 +27,11 @@ interface HackerNewsAlgoliaApi {
   suspend fun getItem(@Path("id") itemId: Long): ItemResponse
 }
 
-class HackerNewsSearchClient(json: Json) {
+class HackerNewsSearchClient(json: Json, client: OkHttpClient) {
   private val retrofit = Retrofit.Builder()
     .baseUrl(BASE_SEARCH_URL)
     .addConverterFactory(json.asConverterFactory("application/json; charset=UTF8".toMediaType()))
+    .client(client)
     .build()
 
   val api: HackerNewsAlgoliaApi = retrofit.create(HackerNewsAlgoliaApi::class.java)

--- a/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
@@ -1,0 +1,44 @@
+package com.emergetools.hackernews.data
+
+import com.emergetools.hackernews.features.stories.FeedType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+typealias ItemId = Long
+typealias Page = List<ItemId>
+
+class ItemRepository(
+  private val baseClient: HackerNewsBaseDataSource,
+) {
+  suspend fun getFeedIds(type: FeedType): Page {
+    return withContext(Dispatchers.IO) {
+      when (type) {
+        FeedType.Top -> {
+          baseClient.api.getTopStoryIds()
+        }
+        FeedType.New -> {
+          baseClient.api.getNewStoryIds()
+        }
+      }
+    }
+  }
+
+  suspend fun getItem(id: ItemId): Item {
+    return withContext(Dispatchers.IO) {
+      baseClient.api.getItem(id)
+    }
+  }
+
+  suspend fun getPage(page: Page): List<Item> {
+    return withContext(Dispatchers.IO) {
+      val result = mutableListOf<Item>()
+      page.forEach { itemId ->
+        val item = baseClient.api.getItem(itemId)
+        result.add(item)
+      }
+      result.toList()
+    }
+  }
+}
+
+fun MutableList<Page>.next() = removeFirst()

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
@@ -4,23 +4,26 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.emergetools.hackernews.data.HackerNewsBaseClient
+import com.emergetools.hackernews.data.Item
+import com.emergetools.hackernews.data.ItemRepository
+import com.emergetools.hackernews.data.Page
+import com.emergetools.hackernews.data.next
 import com.emergetools.hackernews.features.comments.CommentsDestinations
-import com.emergetools.hackernews.features.stories.StoriesAction.LoadFeedIds
-import kotlinx.coroutines.Dispatchers
+import com.emergetools.hackernews.features.stories.StoriesAction.LoadItems
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 enum class FeedType(val label: String) {
   Top("Top"),
   New("New")
 }
+
 data class StoriesState(
   val stories: List<StoryItem>,
-  val feed: FeedType = FeedType.Top
+  val feed: FeedType = FeedType.Top,
+  val loading: Boolean = true
 )
 
 sealed class StoryItem(open val id: Long) {
@@ -36,46 +39,69 @@ sealed class StoryItem(open val id: Long) {
 }
 
 sealed class StoriesAction {
-  data object LoadFeedIds : StoriesAction()
-  data class LoadStory(val id: Long): StoriesAction()
+  data object LoadItems : StoriesAction()
+  data object LoadNextPage : StoriesAction()
   data class SelectStory(val id: Long) : StoriesAction()
   data class SelectComments(val id: Long) : StoriesAction()
   data class SelectFeed(val feed: FeedType) : StoriesAction()
 }
 
-// TODO(rikin): Second pass at Navigation Setup
 sealed interface StoriesNavigation {
   data class GoToStory(val closeup: StoriesDestinations.Closeup) : StoriesNavigation
   data class GoToComments(val comments: CommentsDestinations.Comments) : StoriesNavigation
 }
 
-class StoriesViewModel(private val baseClient: HackerNewsBaseClient) : ViewModel() {
+class StoriesViewModel(private val itemRepository: ItemRepository) : ViewModel() {
   private val internalState = MutableStateFlow(StoriesState(stories = emptyList()))
   val state = internalState.asStateFlow()
 
+  // TODO: decide if this should be in the ViewModel or the Repository
+  private val pages = mutableListOf<Page>()
+
   init {
-    actions(LoadFeedIds)
+    actions(LoadItems)
   }
 
   fun actions(action: StoriesAction) {
     when (action) {
-      LoadFeedIds -> {
+      LoadItems -> {
         viewModelScope.launch {
-          withContext(Dispatchers.IO) {
-            val ids = when(internalState.value.feed) {
-              FeedType.Top -> {
-                baseClient.api.getTopStoryIds()
-              }
-              FeedType.New -> {
-                baseClient.api.getNewStoryIds()
-              }
-            }
+          pages.addAll(
+            itemRepository
+              .getFeedIds(internalState.value.feed)
+              .chunked(FEED_PAGE_SIZE)
+          )
+          val page = pages.next()
+          Log.d("Feed", "Loading first page: $page")
+          internalState.update { current ->
+            current.copy(
+              stories = page.map { StoryItem.Loading(it) },
+              loading = true
+            )
+          }
 
-            internalState.update { current ->
-              current.copy(
-                stories = ids.map { StoryItem.Loading(it) }
+          var newStories = itemRepository
+            .getPage(page)
+            .map<Item, StoryItem> { item ->
+              StoryItem.Content(
+                id = item.id,
+                title = item.title!!,
+                author = item.by!!,
+                score = item.score ?: 0,
+                commentCount = item.descendants ?: 0,
+                url = item.url
               )
             }
+
+          if (pages.isNotEmpty()) {
+            newStories = newStories + StoryItem.Loading(0L)
+          }
+
+          internalState.update { current ->
+            current.copy(
+              stories = newStories,
+              loading = false
+            )
           }
         }
       }
@@ -95,30 +121,42 @@ class StoriesViewModel(private val baseClient: HackerNewsBaseClient) : ViewModel
             stories = emptyList()
           )
         }
-        actions(LoadFeedIds)
+        actions(LoadItems)
       }
 
-      is StoriesAction.LoadStory -> {
-        viewModelScope.launch(Dispatchers.IO) {
-          val item = baseClient.api.getItem(action.id)
-          Log.d("Feed", "Loaded item ${action.id}")
-          internalState.update { current ->
-            current.copy(
-              stories = current.stories.map {
-                if (it.id == item.id) {
-                  StoryItem.Content(
-                    id = item.id,
-                    title = item.title!!,
-                    author = item.by!!,
-                    score = item.score ?: 0,
-                    commentCount = item.descendants ?: 0,
-                    url = item.url
-                  )
-                } else {
-                  it
-                }
+      StoriesAction.LoadNextPage -> {
+        if (pages.isNotEmpty() && !state.value.loading) {
+          viewModelScope.launch {
+            val page = pages.next()
+            Log.d("Feed", "Loading next page: $page")
+            internalState.update { current ->
+              current.copy(loading = true)
+            }
+
+            var storiesToAdd = itemRepository
+              .getPage(page)
+              .map<Item, StoryItem> { item ->
+                StoryItem.Content(
+                  id = item.id,
+                  title = item.title!!,
+                  author = item.by!!,
+                  score = item.score ?: 0,
+                  commentCount = item.descendants ?: 0,
+                  url = item.url
+                )
               }
-            )
+
+            if (pages.isNotEmpty()) {
+              storiesToAdd = storiesToAdd + StoryItem.Loading(0L)
+            }
+
+            internalState.update { current ->
+              val newStories = current.stories.subList(0, current.stories.lastIndex) + storiesToAdd
+              current.copy(
+                stories = newStories,
+                loading = false
+              )
+            }
           }
         }
       }
@@ -126,9 +164,11 @@ class StoriesViewModel(private val baseClient: HackerNewsBaseClient) : ViewModel
   }
 
   @Suppress("UNCHECKED_CAST")
-  class Factory(private val baseClient: HackerNewsBaseClient) : ViewModelProvider.Factory {
+  class Factory(private val itemRepository: ItemRepository) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-      return StoriesViewModel(baseClient) as T
+      return StoriesViewModel(itemRepository) as T
     }
   }
 }
+
+const val FEED_PAGE_SIZE = 20

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesRouting.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesRouting.kt
@@ -12,9 +12,9 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
-import com.emergetools.baseClient
 import com.emergetools.hackernews.features.stories.StoriesDestinations.Closeup
 import com.emergetools.hackernews.features.stories.StoriesDestinations.Feed
+import com.emergetools.itemRepository
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -38,7 +38,7 @@ fun NavGraphBuilder.storiesGraph(navController: NavController) {
 
       val model = viewModel<StoriesViewModel>(
         factory = StoriesViewModel.Factory(
-          baseClient = context.baseClient()
+          itemRepository = context.itemRepository()
         )
       )
       val state by model.state.collectAsState()
@@ -51,8 +51,8 @@ fun NavGraphBuilder.storiesGraph(navController: NavController) {
             is StoriesNavigation.GoToComments -> {
               navController.navigate(place.comments)
             }
+
             is StoriesNavigation.GoToStory -> {
-//              navController.navigate(place.closeup)
               customTabsIntent.launchUrl(context, Uri.parse(place.closeup.url))
             }
           }
@@ -60,7 +60,7 @@ fun NavGraphBuilder.storiesGraph(navController: NavController) {
       )
     }
     composable<Closeup> { entry ->
-      val closeup: Closeup =  entry.toRoute()
+      val closeup: Closeup = entry.toRoute()
       StoryScreen(closeup.url)
     }
   }

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -57,15 +56,22 @@ fun StoriesScreen(
   actions: (StoriesAction) -> Unit,
   navigation: (StoriesNavigation) -> Unit
 ) {
+  fun LazyListState.atEndOfList(): Boolean {
+    return layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1
+  }
+
   val listState = rememberLazyListState()
-  val reachedEnd by remember {
+
+  val shouldLoadMore by remember {
     derivedStateOf {
-      listState.isCloseToEnd()
+      listState.atEndOfList()
     }
   }
 
-  LaunchedEffect(reachedEnd) {
-    actions(StoriesAction.LoadNextPage)
+  LaunchedEffect(shouldLoadMore) {
+    if (shouldLoadMore) {
+      actions(StoriesAction.LoadNextPage)
+    }
   }
 
   Column(
@@ -369,8 +375,4 @@ fun StoryRow(
       }
     }
   }
-}
-
-fun LazyListState.isCloseToEnd(): Boolean {
-  return layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - (FEED_PAGE_SIZE / 2)
 }

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
@@ -1,5 +1,6 @@
 package com.emergetools.hackernews.features.stories
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -24,6 +26,7 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,6 +54,7 @@ fun StoriesScreen(
   actions: (StoriesAction) -> Unit,
   navigation: (StoriesNavigation) -> Unit
 ) {
+  val listState = rememberLazyListState()
   Column(
     modifier = modifier.background(color = MaterialTheme.colorScheme.background),
     horizontalAlignment = Alignment.CenterHorizontally,
@@ -61,6 +65,7 @@ fun StoriesScreen(
       onSelected = { actions(StoriesAction.SelectFeed(it)) }
     )
     LazyColumn(
+      state = listState,
       modifier = Modifier
         .fillMaxWidth()
         .weight(1f)
@@ -90,6 +95,9 @@ fun StoriesScreen(
                 comments = CommentsDestinations.Comments(it.id)
               )
             )
+          },
+          onLoadRequested = {
+            actions(StoriesAction.LoadStory(it.id))
           }
         )
       }
@@ -209,7 +217,8 @@ private fun StoryRowPreview() {
         url = ""
       ),
       onClick = {},
-      onCommentClicked = {}
+      onCommentClicked = {},
+      onLoadRequested = {}
     )
   }
 }
@@ -221,7 +230,8 @@ private fun StoryRowLoadingPreview() {
     StoryRow(
       item = StoryItem.Loading(id = 1L),
       onClick = {},
-      onCommentClicked = {}
+      onCommentClicked = {},
+      onLoadRequested = {}
     )
   }
 }
@@ -231,7 +241,8 @@ fun StoryRow(
   modifier: Modifier = Modifier,
   item: StoryItem,
   onClick: (StoryItem.Content) -> Unit,
-  onCommentClicked: (StoryItem.Content) -> Unit
+  onCommentClicked: (StoryItem.Content) -> Unit,
+  onLoadRequested: (StoryItem.Loading) -> Unit
 ) {
   when (item) {
     is StoryItem.Content -> {
@@ -311,14 +322,14 @@ fun StoryRow(
           Box(
             modifier = Modifier
               .fillMaxWidth(0.8f)
-              .height(20.dp)
+              .height(18.dp)
               .clip(CircleShape)
               .background(color = Color.LightGray)
           )
           Box(
             modifier = Modifier
               .fillMaxWidth(0.45f)
-              .height(20.dp)
+              .height(18.dp)
               .clip(CircleShape)
               .background(color = Color.Gray)
           )
@@ -342,6 +353,10 @@ fun StoryRow(
             )
           }
         }
+      }
+
+      SideEffect {
+        onLoadRequested(item)
       }
     }
   }


### PR DESCRIPTION
> This is an idea I have to load the feed lazily given the current infrastructure.
> 
> When we request a feed, we have a list of ID's, so we can populate our LazyList with a bunch of Loading State items.
> 
> Whenever I Loading State item comes into the Composition, it launches a `SideEffect` which will call up to the ViewModel to fetch that item. This seems like a decent approach without having to explicitly manage a paging mechanism in the ViewModel.

After second thought, I think the better approach is paging. And since we don't have actual paging via the API, we can simulate it.

Created a simple repository layer which wraps the actual base client, and adds the ability to request pages.
The requests are still sequential, but that can be updated later to be a series of async requests.

Some rationale here is that although with first approach we can keep scrolling, a fling will cause a bunch of network requests which could end up being quite costly.

The only thing that is a bit funky is the LazyList detecting how close we are to the end logic. I think this solution works but it probably needs more testing.

