### PR TITLE
Fixing a crash when loading Feeds

### DIFF
--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -36,8 +37,8 @@ sealed interface BaseResponse {
 
 object BaseResponseSerializer : JsonContentPolymorphicSerializer<BaseResponse>(BaseResponse::class) {
   override fun selectDeserializer(element: JsonElement) = when {
-    "id" in element.jsonObject -> BaseResponse.Item.serializer()
-    else -> BaseResponse.NullResponse.serializer()
+    element is JsonNull -> BaseResponse.NullResponse.serializer()
+    else -> BaseResponse.Item.serializer()
   }
 }
 

--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsBaseDataSource.kt
@@ -2,6 +2,9 @@ package com.emergetools.hackernews.data
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -11,19 +14,32 @@ import retrofit2.http.Path
 
 const val BASE_FIREBASE_URL = "https://hacker-news.firebaseio.com/v0/"
 
-@Serializable
-data class Item(
-  val id: Long,
-  val type: String,
-  val time: Long,
-  val by: String? = null,
-  val title: String? = null,
-  val score: Int? = null,
-  val url: String? = null,
-  val descendants: Int? = null,
-  val kids: List<Long>? = null,
-  val text: String? = null
-)
+@Serializable(with = BaseResponseSerializer::class)
+sealed interface BaseResponse {
+  @Serializable
+  data class Item(
+    val id: Long,
+    val type: String,
+    val time: Long,
+    val by: String? = null,
+    val title: String? = null,
+    val score: Int? = null,
+    val url: String? = null,
+    val descendants: Int? = null,
+    val kids: List<Long>? = null,
+    val text: String? = null
+  ): BaseResponse
+
+  @Serializable
+  data object NullResponse: BaseResponse
+}
+
+object BaseResponseSerializer : JsonContentPolymorphicSerializer<BaseResponse>(BaseResponse::class) {
+  override fun selectDeserializer(element: JsonElement) = when {
+    "id" in element.jsonObject -> BaseResponse.Item.serializer()
+    else -> BaseResponse.NullResponse.serializer()
+  }
+}
 
 interface HackerNewsBaseApi {
   @GET("topstories.json")
@@ -33,7 +49,7 @@ interface HackerNewsBaseApi {
   suspend fun getNewStoryIds(): List<Long>
 
   @GET("item/{id}.json")
-  suspend fun getItem(@Path("id") itemId: Long): Item
+  suspend fun getItem(@Path("id") itemId: Long): BaseResponse
 }
 
 class HackerNewsBaseDataSource(json: Json, client: OkHttpClient) {

--- a/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
@@ -1,5 +1,7 @@
 package com.emergetools.hackernews.data
 
+import com.emergetools.hackernews.data.BaseResponse.Item
+import com.emergetools.hackernews.data.BaseResponse.NullResponse
 import com.emergetools.hackernews.features.stories.FeedType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -27,14 +29,16 @@ class ItemRepository(
     return withContext(Dispatchers.IO) {
       val result = mutableListOf<Item>()
       page.forEach { itemId ->
-        val item = baseClient.api.getItem(itemId)
-        result.add(item)
+        val response = baseClient.api.getItem(itemId)
+        if (response is Item) {
+          result.add(response)
+        }
       }
       result.toList()
     }
   }
 }
 
-fun MutableList<Page>.next() = removeFirst()
+fun MutableList<Page>.next() = removeAt(0)
 
 

--- a/android/app/src/main/java/com/emergetools/hackernews/features/comments/CommentsDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/comments/CommentsDomain.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.JsonNull.content
 import java.time.OffsetDateTime
 
 sealed interface CommentsState {

--- a/android/app/src/main/java/com/emergetools/hackernews/features/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/settings/SettingsScreen.kt
@@ -15,13 +15,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.ThumbUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +34,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RadialGradient
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
@@ -4,8 +4,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.emergetools.hackernews.data.BaseResponse
+import com.emergetools.hackernews.data.BaseResponse.Item
 import com.emergetools.hackernews.data.BookmarkDao
-import com.emergetools.hackernews.data.Item
 import com.emergetools.hackernews.data.ItemRepository
 import com.emergetools.hackernews.data.Page
 import com.emergetools.hackernews.data.next


### PR DESCRIPTION
Apparently there is a chance that the API just straight up returns null as a valid response. In this scenario our JsonDeserializer fails and crashes the app. And in the case that this value is in the first page of the feed, we will constantly crash on startup.

In order to safeguard against this, I just created a wrapper type and a custom deserializer that just checks if a gauranteed property exists in the json response, and if it does, use the normal item deserializer, otherwise map it to an empty object that is mostly a marker type, we can just ignore it.