### PR TITLE
A new comment loading approach

### DIFF
--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
@@ -1,6 +1,5 @@
 package com.emergetools.hackernews.data
 
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.FormBody
@@ -90,7 +89,6 @@ class HackerNewsWebClient(
       val document = Jsoup.parse(response.body?.string()!!)
       val postInfo = document.postInfo(itemId)
       val commentInfos = document.commentInfos()
-      Log.d("Page Comments", "Comments: $commentInfos")
       val commentFormData = document.commentFormData()
 
       PostPage(

--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
@@ -1,5 +1,6 @@
 package com.emergetools.hackernews.data
 
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.FormBody
@@ -15,7 +16,7 @@ private const val COMMENT_URL = BASE_WEB_URL + "comment"
 
 data class PostPage(
   val postInfo: PostInfo,
-  val commentInfoMap: Map<Long, CommentInfo>,
+  val commentInfos: List<CommentInfo>,
   val commentFormData: CommentFormData?
 )
 
@@ -28,7 +29,11 @@ data class PostInfo(
 data class CommentInfo(
   val id: Long,
   val upvoted: Boolean,
-  val upvoteUrl: String
+  val upvoteUrl: String,
+  val text: String,
+  val user: String,
+  val age: String,
+  val level: Int,
 )
 
 data class CommentFormData(
@@ -83,14 +88,15 @@ class HackerNewsWebClient(
       ).execute()
 
       val document = Jsoup.parse(response.body?.string()!!)
-      val itemPageInfo = document.postInfo(itemId)
-      val commentPageInfoMap = document.commentInfos()
-      val addCommentFormData = document.commentFormData()
+      val postInfo = document.postInfo(itemId)
+      val commentInfos = document.commentInfos()
+      Log.d("Page Comments", "Comments: $commentInfos")
+      val commentFormData = document.commentFormData()
 
       PostPage(
-        postInfo = itemPageInfo,
-        commentInfoMap = commentPageInfoMap,
-        commentFormData = addCommentFormData
+        postInfo = postInfo,
+        commentInfos = commentInfos,
+        commentFormData = commentFormData
       )
     }
   }
@@ -104,20 +110,36 @@ class HackerNewsWebClient(
     )
   }
 
-  private fun Document.commentInfos(): Map<Long, CommentInfo> {
+  /**
+   * The comment route on the website gives us a list of comments in order
+   * and also gives us a "level". Now this doesn't do child/parent association
+   * for us, but it does make rendering and updating comment state a lot easier.
+   */
+  private fun Document.commentInfos(): List<CommentInfo> {
     val commentTree = select("table.comment-tree")
-    val commentUpvoteLinks = commentTree.select("a[id^=up_]")
-    return commentUpvoteLinks
-      .groupBy(
-        keySelector = { it.id().substring(3).toLong() },
-        valueTransform = {
-          CommentInfo(
-            id = it.id().substring(3).toLong(),
-            upvoted = it.hasClass("nosee"),
-            upvoteUrl = BASE_WEB_URL + it.attr("href")
-          )
-        }
-      ).mapValues { it.value[0] }
+    val comments = commentTree.select("tr.athing.comtr")
+    val infos = comments.map { commentElement ->
+      val id = commentElement.id().toLong()
+      val level = commentElement.select("td.ind").attr("indent").toInt()
+      val text = commentElement.select("div.commtext").text()
+      val user = commentElement.select("a.hnuser").text()
+      val time = commentElement.select("span.age").attr("title")
+      val upvoteLink = commentElement.select("a[id^=up_]")
+      val url = BASE_WEB_URL + upvoteLink.attr("href")
+      val upvoted = upvoteLink.hasClass("nosee")
+
+      CommentInfo(
+        id = id,
+        user = user,
+        age = time,
+        text = text,
+        level = level,
+        upvoteUrl = url,
+        upvoted = upvoted
+      )
+    }
+
+    return infos
   }
 
   private fun Document.commentFormData(): CommentFormData? {
@@ -153,7 +175,7 @@ class HackerNewsWebClient(
     gotoUrl: String,
     hmac: String,
     text: String
-  ): Boolean {
+  ): List<CommentInfo> {
     return withContext(Dispatchers.IO) {
       val response = httpClient.newCall(
         Request.Builder()
@@ -169,7 +191,8 @@ class HackerNewsWebClient(
           .build()
       ).execute()
 
-      response.isSuccessful
+      val document = Jsoup.parse(response.body?.string()!!)
+      document.commentInfos()
     }
   }
 }

--- a/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
@@ -37,12 +37,6 @@ class ItemRepository(
       result.toList()
     }
   }
-
-  suspend fun getItem(itemId: Long): BaseResponse {
-    return withContext(Dispatchers.IO) {
-      baseClient.api.getItem(itemId)
-    }
-  }
 }
 
 fun MutableList<Page>.next() = removeAt(0)

--- a/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
@@ -1,7 +1,6 @@
 package com.emergetools.hackernews.data
 
 import com.emergetools.hackernews.data.BaseResponse.Item
-import com.emergetools.hackernews.data.BaseResponse.NullResponse
 import com.emergetools.hackernews.features.stories.FeedType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -18,6 +17,7 @@ class ItemRepository(
         FeedType.Top -> {
           baseClient.api.getTopStoryIds()
         }
+
         FeedType.New -> {
           baseClient.api.getNewStoryIds()
         }
@@ -35,6 +35,12 @@ class ItemRepository(
         }
       }
       result.toList()
+    }
+  }
+
+  suspend fun getItem(itemId: Long): BaseResponse {
+    return withContext(Dispatchers.IO) {
+      baseClient.api.getItem(itemId)
     }
   }
 }

--- a/android/app/src/main/java/com/emergetools/hackernews/features/comments/CommentsScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/comments/CommentsScreen.kt
@@ -119,7 +119,8 @@ fun CommentsScreen(
               actions(
                 CommentsAction.LikeComment(
                   id = it.id,
-                  url = it.upvoteUrl
+                  url = it.upvoteUrl,
+                  upvoted = it.upvoted
                 )
               )
             } else {
@@ -221,10 +222,14 @@ private fun CommentsScreenLoadingPreview() {
 }
 
 @Composable
-fun CommentRow(state: CommentState, onLikeTapped: (CommentState.Content) -> Unit) {
+fun CommentRow(
+  modifier: Modifier = Modifier,
+  state: CommentState,
+  onLikeTapped: (CommentState.Content) -> Unit
+) {
   val startPadding = (state.level * 16).dp
   Column(
-    modifier = Modifier
+    modifier = modifier
       .padding(start = startPadding)
       .fillMaxWidth()
       .heightIn(min = 80.dp)
@@ -262,7 +267,13 @@ fun CommentRow(state: CommentState, onLikeTapped: (CommentState.Content) -> Unit
             modifier = Modifier
               .wrapContentSize()
               .clip(CircleShape)
-              .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+              .background(
+                color = if (state.upvoted) {
+                  HackerGreen.copy(alpha = 0.2f)
+                } else {
+                  MaterialTheme.colorScheme.surfaceContainerHighest
+                }
+              )
               .padding(vertical = 4.dp, horizontal = 8.dp)
               .clickable { onLikeTapped(state) },
             contentAlignment = Alignment.Center
@@ -270,7 +281,11 @@ fun CommentRow(state: CommentState, onLikeTapped: (CommentState.Content) -> Unit
             Icon(
               modifier = Modifier.size(12.dp),
               imageVector = Icons.Default.ThumbUp,
-              tint = MaterialTheme.colorScheme.onSurface,
+              tint = if (state.upvoted) {
+                HackerGreen
+              } else {
+                MaterialTheme.colorScheme.onSurface
+              },
               contentDescription = "upvote"
             )
           }
@@ -332,7 +347,11 @@ fun CommentRow(state: CommentState, onLikeTapped: (CommentState.Content) -> Unit
     }
   }
   state.children.forEach { child ->
-    CommentRow(state = child, onLikeTapped = onLikeTapped)
+    CommentRow(
+      modifier = modifier,
+      state = child,
+      onLikeTapped = onLikeTapped
+    )
   }
 }
 

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
@@ -1,10 +1,8 @@
 package com.emergetools.hackernews.features.stories
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.emergetools.hackernews.data.BaseResponse
 import com.emergetools.hackernews.data.BaseResponse.Item
 import com.emergetools.hackernews.data.BookmarkDao
 import com.emergetools.hackernews.data.ItemRepository
@@ -88,24 +86,25 @@ class StoriesViewModel(
   }
 
   private fun observeBookmarks() {
-   viewModelScope.launch {
-     bookmarkDao.getAllBookmarks().collect { bookmarks ->
-       internalState.update { current ->
-         current.copy(
-           stories = current.stories
-             .filterIsInstance<StoryItem.Content>()
-             .map { story ->
-               val isBookmarked = bookmarks.find { it.id == story.id } != null
-               story.copy(
-                 bookmarked = isBookmarked
-               )
-             },
-           bookmarks = bookmarks.map { it.toStoryItem() },
-         )
-       }
-     }
-   }
+    viewModelScope.launch {
+      bookmarkDao.getAllBookmarks().collect { bookmarks ->
+        internalState.update { current ->
+          current.copy(
+            stories = current.stories
+              .filterIsInstance<StoryItem.Content>()
+              .map { story ->
+                val isBookmarked = bookmarks.find { it.id == story.id } != null
+                story.copy(
+                  bookmarked = isBookmarked
+                )
+              },
+            bookmarks = bookmarks.map { it.toStoryItem() },
+          )
+        }
+      }
+    }
   }
+
   fun actions(action: StoriesAction) {
     when (action) {
       LoadItems -> {
@@ -191,7 +190,6 @@ class StoriesViewModel(
         if (pages.isNotEmpty() && internalState.value.loading == LoadingState.Idle) {
           fetchJob = viewModelScope.launch {
             val page = pages.next()
-            Log.d("Feed", "Loading next page: $page")
             val newStories = fetchPage(page) {
               internalState.update { current ->
                 current.copy(loading = LoadingState.LoadingPage)
@@ -241,7 +239,6 @@ class StoriesViewModel(
     var newStories = itemRepository
       .getPage(page)
       .map<Item, StoryItem> { item ->
-        Log.d("Feed", "Item: $item")
         StoryItem.Content(
           id = item.id,
           title = item.title!!,


### PR DESCRIPTION
Previously we were loading the comment tree by using the `search` api. This was nice but there are a few drawbacks:
- When adding a comment, there is some delay before the comment shows up in the response. This means we would have to juggle some local state, or just treat it as a fire and forget request.
- If we like a comment, updating the backing comment tree is a bit more complex then, say, updating a list of comments.

Since we were already scraping the comments page for upvote links for each comment, I figured we could try just using the comments page as our data source for comments. The results were fairly good, a simplified model of comments, and immediate updated when we post a top-level comment.

This does get rid of the parent-child relationship between comments, which probably should be revisited, especially when it comes to hiding comment sub-trees. However, this makes the rest of the experience much better.