### PR TITLE
Simple Feed Error Handling

### DIFF
--- a/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/HackerNewsWebClient.kt
@@ -47,7 +47,8 @@ data class CommentFormData(
 
 enum class LoginResponse {
   Success,
-  Failed
+  Failed,
+  Error
 }
 
 class HackerNewsWebClient(
@@ -55,28 +56,32 @@ class HackerNewsWebClient(
 ) {
   suspend fun login(username: String, password: String): LoginResponse {
     return withContext(Dispatchers.IO) {
-      val response = httpClient.newCall(
-        Request.Builder()
-          .url(LOGIN_URL)
-          .post(
-            FormBody.Builder()
-              .add("acct", username)
-              .add("pw", password)
-              .build()
-          )
-          .build()
-      ).execute()
+      try {
+        val response = httpClient.newCall(
+          Request.Builder()
+            .url(LOGIN_URL)
+            .post(
+              FormBody.Builder()
+                .add("acct", username)
+                .add("pw", password)
+                .build()
+            )
+            .build()
+        ).execute()
 
-      val document = Jsoup.parse(response.body?.string()!!)
+        val document = Jsoup.parse(response.body?.string()!!)
 
-      val body = document.body()
-      val firstElement = body.firstChild()
-      val loginFailed = firstElement?.toString()?.contains("Bad login") ?: false
+        val body = document.body()
+        val firstElement = body.firstChild()
+        val loginFailed = firstElement?.toString()?.contains("Bad login") ?: false
 
-      if (loginFailed) {
-        LoginResponse.Failed
-      } else {
-        LoginResponse.Success
+        if (loginFailed) {
+          LoginResponse.Failed
+        } else {
+          LoginResponse.Success
+        }
+      } catch (error: Exception) {
+        LoginResponse.Error
       }
     }
   }

--- a/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/ItemRepository.kt
@@ -1,5 +1,6 @@
 package com.emergetools.hackernews.data
 
+import android.util.Log
 import com.emergetools.hackernews.data.BaseResponse.Item
 import com.emergetools.hackernews.features.stories.FeedType
 import kotlinx.coroutines.Dispatchers
@@ -8,30 +9,49 @@ import kotlinx.coroutines.withContext
 typealias ItemId = Long
 typealias Page = List<ItemId>
 
+sealed class FeedIdResponse(val page: Page) {
+  class Success(page: Page) : FeedIdResponse(page)
+  data class Error(val message: String) : FeedIdResponse(emptyList())
+}
+
 class ItemRepository(
   private val baseClient: HackerNewsBaseDataSource,
 ) {
-  suspend fun getFeedIds(type: FeedType): Page {
+  suspend fun getFeedIds(type: FeedType): FeedIdResponse {
     return withContext(Dispatchers.IO) {
       when (type) {
         FeedType.Top -> {
-          baseClient.api.getTopStoryIds()
+          try {
+            val result = baseClient.api.getTopStoryIds()
+            FeedIdResponse.Success(result)
+          } catch (error: Exception) {
+            FeedIdResponse.Error(error.message.orEmpty())
+          }
         }
 
         FeedType.New -> {
-          baseClient.api.getNewStoryIds()
+          try {
+            val result = baseClient.api.getNewStoryIds()
+            FeedIdResponse.Success(result)
+          } catch (error: Exception) {
+            FeedIdResponse.Error(error.message.orEmpty())
+          }
         }
       }
     }
   }
 
   suspend fun getPage(page: Page): List<Item> {
+    Log.d("Feed", "Loading Page: $page")
     return withContext(Dispatchers.IO) {
       val result = mutableListOf<Item>()
       page.forEach { itemId ->
-        val response = baseClient.api.getItem(itemId)
-        if (response is Item) {
-          result.add(response)
+        try {
+          val response = baseClient.api.getItem(itemId)
+          if (response is Item) {
+            result.add(response)
+          }
+        } catch (_: Exception) {
         }
       }
       result.toList()

--- a/android/app/src/main/java/com/emergetools/hackernews/features/login/LoginDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/login/LoginDomain.kt
@@ -15,6 +15,7 @@ enum class LoginStatus {
   Success,
   Failed
 }
+
 data class LoginState(
   val username: String = "",
   val password: String = "",
@@ -22,21 +23,21 @@ data class LoginState(
 )
 
 sealed interface LoginAction {
-  data class UsernameUpdated(val input: String): LoginAction
-  data class PasswordUpdated(val input: String): LoginAction
-  data object LoginSubmit: LoginAction
+  data class UsernameUpdated(val input: String) : LoginAction
+  data class PasswordUpdated(val input: String) : LoginAction
+  data object LoginSubmit : LoginAction
 }
 
 sealed interface LoginNavigation {
-  data object Dismiss: LoginNavigation
+  data object Dismiss : LoginNavigation
 }
 
-class LoginViewModel(private val webClient: HackerNewsWebClient): ViewModel() {
+class LoginViewModel(private val webClient: HackerNewsWebClient) : ViewModel() {
   private val internalState = MutableStateFlow(LoginState())
   val state = internalState.asStateFlow()
 
   fun actions(action: LoginAction) {
-    when(action) {
+    when (action) {
       LoginAction.LoginSubmit -> {
         viewModelScope.launch {
           val response = webClient.login(
@@ -50,7 +51,8 @@ class LoginViewModel(private val webClient: HackerNewsWebClient): ViewModel() {
                 LoginResponse.Success -> {
                   LoginStatus.Success
                 }
-                LoginResponse.Failed -> {
+
+                LoginResponse.Failed, LoginResponse.Error -> {
                   LoginStatus.Failed
                 }
               }
@@ -58,6 +60,7 @@ class LoginViewModel(private val webClient: HackerNewsWebClient): ViewModel() {
           }
         }
       }
+
       is LoginAction.PasswordUpdated -> {
         internalState.update { current ->
           current.copy(
@@ -65,6 +68,7 @@ class LoginViewModel(private val webClient: HackerNewsWebClient): ViewModel() {
           )
         }
       }
+
       is LoginAction.UsernameUpdated -> {
         internalState.update { current ->
           current.copy(
@@ -76,7 +80,7 @@ class LoginViewModel(private val webClient: HackerNewsWebClient): ViewModel() {
   }
 
   @Suppress("UNCHECKED_CAST")
-  class Factory(private val webClient: HackerNewsWebClient): ViewModelProvider.Factory {
+  class Factory(private val webClient: HackerNewsWebClient) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       return LoginViewModel(webClient) as T
     }

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesDomain.kt
@@ -1,6 +1,5 @@
 package com.emergetools.hackernews.features.stories
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -116,10 +115,9 @@ class StoriesViewModel(
         fetchJob?.cancel()
 
         fetchJob = viewModelScope.launch {
-          internalState.update { it.copy(loading = LoadingState.Refreshing) }
+          internalState.update { it.copy(loading = LoadingState.Loading) }
           when (val response = itemRepository.getFeedIds(internalState.value.feed)) {
             is FeedIdResponse.Error -> {
-              Log.e("Feed Load Error", response.message)
               delay(500)
               internalState.update { current ->
                 current.copy(
@@ -168,7 +166,6 @@ class StoriesViewModel(
           }
           when (val response = itemRepository.getFeedIds(internalState.value.feed)) {
             is FeedIdResponse.Error -> {
-              Log.e("Feed Load Error", response.message)
               delay(500)
               internalState.update { current ->
                 current.copy(loading = LoadingState.Error)

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
@@ -115,39 +115,8 @@ fun StoriesScreen(
       LazyColumn(state = listState) {
         if (state.loading == LoadingState.Error) {
           item {
-            Column(
-              modifier = Modifier
-                .animateItem()
-                .fillMaxWidth()
-                .height(200.dp),
-              verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
-              horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-              Icon(
-                imageVector = Icons.Rounded.Warning,
-                tint = HackerRed,
-                contentDescription = "Failed to Load",
-              )
-
-              Text(
-                text = "Failed to Load Feed",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurface
-              )
-
-              Button(
-                colors = ButtonDefaults.buttonColors(
-                  containerColor = HackerRed,
-                  contentColor = Color.White
-                ),
-                onClick = {
-                  actions(StoriesAction.LoadItems)
-                }) {
-                Icon(
-                  imageVector = Icons.Rounded.Refresh,
-                  contentDescription = "Reload Feed"
-                )
-              }
+            FeedErrorCard(modifier = Modifier.animateItem()) {
+              actions(StoriesAction.LoadItems)
             }
           }
         }
@@ -436,6 +405,51 @@ private fun StoryRowLoadingPreview() {
   }
 }
 
+@Composable
+fun FeedErrorCard(modifier: Modifier = Modifier, onRefresh: () -> Unit) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .height(200.dp)
+      .background(color = MaterialTheme.colorScheme.background),
+    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Icon(
+      imageVector = Icons.Rounded.Warning,
+      tint = HackerRed,
+      contentDescription = "Failed to Load",
+    )
+
+    Text(
+      text = "Failed to Load Feed",
+      style = MaterialTheme.typography.titleSmall,
+      color = MaterialTheme.colorScheme.onBackground
+    )
+
+    Button(
+      colors = ButtonDefaults.buttonColors(
+        containerColor = HackerRed,
+        contentColor = Color.White
+      ),
+      onClick = { onRefresh() }) {
+      Icon(
+        imageVector = Icons.Rounded.Refresh,
+        contentDescription = "Reload Feed"
+      )
+    }
+  }
+}
+
+@PreviewLightDark
+@Composable
+fun FeedErrorCardPreview() {
+  HackerNewsTheme {
+    FeedErrorCard(
+      onRefresh = {}
+    )
+  }
+}
 
 @Composable
 private fun FeedSelection(

--- a/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/features/stories/StoriesScreen.kt
@@ -26,6 +26,11 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +65,7 @@ import com.emergetools.hackernews.R
 import com.emergetools.hackernews.features.comments.CommentsDestinations
 import com.emergetools.hackernews.ui.theme.HackerNewsTheme
 import com.emergetools.hackernews.ui.theme.HackerOrange
+import com.emergetools.hackernews.ui.theme.HackerRed
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -98,21 +104,53 @@ fun StoriesScreen(
     verticalArrangement = Arrangement.spacedBy(8.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    FeedSelection(
-      feedType = state.feed,
-      onSelected = { actions(StoriesAction.SelectFeed(it)) }
-    )
+    FeedSelection(feedType = state.feed, onSelected = { actions(StoriesAction.SelectFeed(it)) })
     PullToRefreshBox(
-      state = pullRefreshState,
-      modifier = Modifier
+      state = pullRefreshState, modifier = Modifier
         .fillMaxWidth()
-        .weight(1f),
-      onRefresh = {
+        .weight(1f), onRefresh = {
         actions(StoriesAction.RefreshItems)
-      },
-      isRefreshing = state.loading == LoadingState.Refreshing
+      }, isRefreshing = state.loading == LoadingState.Refreshing
     ) {
       LazyColumn(state = listState) {
+        if (state.loading == LoadingState.Error) {
+          item {
+            Column(
+              modifier = Modifier
+                .animateItem()
+                .fillMaxWidth()
+                .height(200.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+              horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+              Icon(
+                imageVector = Icons.Rounded.Warning,
+                tint = HackerRed,
+                contentDescription = "Failed to Load",
+              )
+
+              Text(
+                text = "Failed to Load Feed",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface
+              )
+
+              Button(
+                colors = ButtonDefaults.buttonColors(
+                  containerColor = HackerRed,
+                  contentColor = Color.White
+                ),
+                onClick = {
+                  actions(StoriesAction.LoadItems)
+                }) {
+                Icon(
+                  imageVector = Icons.Rounded.Refresh,
+                  contentDescription = "Reload Feed"
+                )
+              }
+            }
+          }
+        }
         items(state.stories) { item ->
           StoryRow(
             modifier = Modifier.animateItem(),
@@ -153,35 +191,30 @@ fun StoriesScreen(
 @Composable
 private fun StoriesScreenPreview() {
   HackerNewsTheme {
-    StoriesScreen(
-      modifier = Modifier.fillMaxSize(),
-      state = StoriesState(
-        stories = listOf(
-          StoryItem.Content(
-            id = 1L,
-            title = "Hello There",
-            author = "heyrikin",
-            score = 10,
-            commentCount = 0,
-            epochTimestamp = 100L,
-            timeLabel = "2h ago",
-            url = ""
-          ),
-          StoryItem.Content(
-            id = 1L,
-            title = "Hello There",
-            author = "heyrikin",
-            score = 10,
-            commentCount = 0,
-            epochTimestamp = 100L,
-            timeLabel = "2h ago",
-            url = ""
-          ),
-        )
-      ),
-      actions = {},
-      navigation = {}
-    )
+    StoriesScreen(modifier = Modifier.fillMaxSize(), state = StoriesState(
+      stories = listOf(
+        StoryItem.Content(
+          id = 1L,
+          title = "Hello There",
+          author = "heyrikin",
+          score = 10,
+          commentCount = 0,
+          epochTimestamp = 100L,
+          timeLabel = "2h ago",
+          url = ""
+        ),
+        StoryItem.Content(
+          id = 1L,
+          title = "Hello There",
+          author = "heyrikin",
+          score = 10,
+          commentCount = 0,
+          epochTimestamp = 100L,
+          timeLabel = "2h ago",
+          url = ""
+        ),
+      )
+    ), actions = {}, navigation = {})
   }
 }
 
@@ -201,55 +234,47 @@ fun StoryRow(
           80f
         } else {
           0f
-        },
-        animationSpec = spring(
+        }, animationSpec = spring(
           dampingRatio = if (item.bookmarked) {
             Spring.DampingRatioMediumBouncy
           } else {
             Spring.DampingRatioNoBouncy
-          },
-          stiffness = Spring.StiffnessLow
-        ),
-        label = "Bookmark Height"
+          }, stiffness = Spring.StiffnessLow
+        ), label = "Bookmark Height"
       )
-      Row(
-        modifier = modifier
-          .fillMaxWidth()
-          .heightIn(min = 80.dp)
-          .background(color = MaterialTheme.colorScheme.background)
-          .clip(shape = RectangleShape)
-          .drawWithContent {
-            drawContent()
-            val startX = size.width * 0.75f
-            val startY = 0f
-            val bookmarkWidth = 50f
+      Row(modifier = modifier
+        .fillMaxWidth()
+        .heightIn(min = 80.dp)
+        .background(color = MaterialTheme.colorScheme.background)
+        .clip(shape = RectangleShape)
+        .drawWithContent {
+          drawContent()
+          val startX = size.width * 0.75f
+          val startY = 0f
+          val bookmarkWidth = 50f
 
-            val path = Path().apply {
-              moveTo(startX, startY)
-              lineTo(startX, startY + bookmarkHeight)
-              lineTo(startX + bookmarkWidth / 2f, startY + bookmarkHeight * 0.75f)
-              lineTo(startX + bookmarkWidth, startY + bookmarkHeight)
-              lineTo(startX + bookmarkWidth, startY)
-            }
-
-            drawPath(
-              path,
-              color = HackerOrange,
-            )
+          val path = Path().apply {
+            moveTo(startX, startY)
+            lineTo(startX, startY + bookmarkHeight)
+            lineTo(startX + bookmarkWidth / 2f, startY + bookmarkHeight * 0.75f)
+            lineTo(startX + bookmarkWidth, startY + bookmarkHeight)
+            lineTo(startX + bookmarkWidth, startY)
           }
-          .combinedClickable(
-            onClick = {
-              onClick(item)
-            },
-            onLongClick = {
-              onBookmark(item)
-            }
+
+          drawPath(
+            path,
+            color = HackerOrange,
           )
-          .padding(8.dp),
+        }
+        .combinedClickable(onClick = {
+          onClick(item)
+        }, onLongClick = {
+          onBookmark(item)
+        })
+        .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(
-          16.dp,
-          alignment = Alignment.CenterHorizontally
+          16.dp, alignment = Alignment.CenterHorizontally
         )
       ) {
         Column(
@@ -327,8 +352,7 @@ fun StoryRow(
           .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(
-          16.dp,
-          alignment = Alignment.CenterHorizontally
+          16.dp, alignment = Alignment.CenterHorizontally
         )
       ) {
         Column(
@@ -421,35 +445,31 @@ private fun FeedSelection(
 ) {
   val selectedTab = remember(feedType) { feedType.ordinal }
 
-  TabRow(
-    selectedTabIndex = selectedTab,
+  TabRow(selectedTabIndex = selectedTab,
     modifier = modifier.wrapContentWidth(),
     containerColor = MaterialTheme.colorScheme.background,
     contentColor = MaterialTheme.colorScheme.onBackground,
     indicator = { tabPositions ->
       if (selectedTab < tabPositions.size) {
-        Box(
-          modifier = Modifier
-            .tabIndicatorOffset(tabPositions[selectedTab])
-            .height(2.dp)
-            .drawBehind {
-              val barWidth = size.width * 0.33f
-              val start = size.center.x - barWidth / 2f
-              val end = size.center.x + barWidth / 2f
-              val bottom = size.height - 16f
-              drawLine(
-                start = Offset(start, bottom),
-                end = Offset(end, bottom),
-                color = HackerOrange,
-                strokeWidth = 4f,
-                cap = StrokeCap.Round,
-              )
-            }
-        )
+        Box(modifier = Modifier
+          .tabIndicatorOffset(tabPositions[selectedTab])
+          .height(2.dp)
+          .drawBehind {
+            val barWidth = size.width * 0.33f
+            val start = size.center.x - barWidth / 2f
+            val end = size.center.x + barWidth / 2f
+            val bottom = size.height - 16f
+            drawLine(
+              start = Offset(start, bottom),
+              end = Offset(end, bottom),
+              color = HackerOrange,
+              strokeWidth = 4f,
+              cap = StrokeCap.Round,
+            )
+          })
       }
     },
-    divider = {}
-  ) {
+    divider = {}) {
     FeedType.entries.forEach { feedType ->
       Text(
         modifier = Modifier
@@ -457,8 +477,7 @@ private fun FeedSelection(
           .padding(8.dp)
           .clickable(
             indication = null,
-            interactionSource = remember { MutableInteractionSource() }
-          ) {
+            interactionSource = remember { MutableInteractionSource() }) {
             onSelected(feedType)
           },
         textAlign = TextAlign.Center,
@@ -473,9 +492,6 @@ private fun FeedSelection(
 @Composable
 private fun FeedSelectionPreview() {
   HackerNewsTheme {
-    FeedSelection(
-      feedType = FeedType.Top,
-      onSelected = {}
-    )
+    FeedSelection(feedType = FeedType.Top, onSelected = {})
   }
 }


### PR DESCRIPTION
In order to make sure that app doesn't just crash constantly, we need to have some basic error handling in place.

The goal of this diff is to have a very simple solution for most cases. For the feed, we can show an error item that allows you to try request the feed again.

I'd love to have a bit more sophistication here, but this is a good first step. At the very least if they lose internet connection the app won't crash.