### PR TITLE
Fix sentry for release, move emerge block out of Android block

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Sentry Config File
+sentry.properties

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,6 +79,10 @@ emerge {
 
 sentry {
   org.set("emerge-tools")
+  projectName.set("hackernews-android")
+
+  // Don't upload source code to Sentry
+  includeSourceContext.set(false)
 }
 
 dependencies {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,23 +57,28 @@ android {
   composeOptions {
     kotlinCompilerExtensionVersion = libs.versions.composeCompilerExtension.get()
   }
-  emerge {
-    snapshots {
-      tag.set("snapshot")
-    }
-
-    vcs {
-      gitHub {
-        repoName.set("hackernews")
-        repoOwner.set("EmergeTools")
-      }
-    }
-  }
   packaging {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"
     }
   }
+}
+
+emerge {
+  snapshots {
+    tag.set("snapshot")
+  }
+
+  vcs {
+    gitHub {
+      repoName.set("hackernews")
+      repoOwner.set("EmergeTools")
+    }
+  }
+}
+
+sentry {
+  org.set("emerge-tools")
 }
 
 dependencies {


### PR DESCRIPTION
Runs sentry setup wizard and configures project.

Also moves emerge block out of android block