### PR TITLE
Fix crash in CommentsScreen due to incorrect timestamp parsing

### DIFF
--- a/android/app/src/main/java/com/emergetools/hackernews/data/remote/HackerNewsWebClient.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/data/remote/HackerNewsWebClient.kt
@@ -135,6 +135,8 @@ class HackerNewsWebClient(
       val text = commentElement.select("div.commtext").html()
       val user = commentElement.select("a.hnuser").text()
       val time = commentElement.select("span.age").attr("title")
+        .split(" ")
+        .first()
       val upvoteLink = commentElement.select("a[id^=up_]")
       val url = BASE_WEB_URL + upvoteLink.attr("href")
       val upvoted = upvoteLink.hasClass("nosee")


### PR DESCRIPTION
## Description

Fixes a crash when navigating to CommentsScreen due to incorrect parsing of timestamp. The returned timestamp withing HTML also contains millis which causes the parsing to fail.

Actual: 2024-11-03T04:53:41 1730609621
Expected: 2024-11-03T04:53:41

This diff simply strips the millis and only uses timestamp to parse the date.


## Steps to reproduce

1. Navigate to Comments screen for any post
2. Notice that the app crashes without the change


## Crash Logs

<details><summary>Stacktrace</summary>
<code>

```
FATAL EXCEPTION: main (Ask Gemini)
                                                                                                    Process: com.emergetools.hackernews.debug, PID: 4649
                                                                                                    java.time.format.DateTimeParseException: Text '2024-11-02T20:55:10 1730580910' could not be parsed, unparsed text found at index 19
                                                                                                    	at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:2053)
                                                                                                    	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1952)
                                                                                                    	at java.time.LocalDateTime.parse(LocalDateTime.java:487)
                                                                                                    	at com.emergetools.hackernews.features.comments.CommentsViewModel.toCommentState(CommentsDomain.kt:356)
                                                                                                    	at com.emergetools.hackernews.features.comments.CommentsViewModel.access$toCommentState(CommentsDomain.kt:176)
                                                                                                    	at com.emergetools.hackernews.features.comments.CommentsViewModel$1.invokeSuspend(CommentsDomain.kt:208)
                                                                                                    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                                                                                                    	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:958)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
                                                                                                    	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@b0924ad, Dispatchers.Main.immediate]
```
</code>
</details> 
