### PR TITLE
Use safe insets to draw content

### DIFF
--- a/android/app/src/main/java/com/emergetools/hackernews/MainActivity.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/MainActivity.kt
@@ -7,8 +7,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -100,7 +102,8 @@ fun App() {
           )
         }
       }
-    }
+    },
+    contentWindowInsets = WindowInsets.safeContent
   ) { innerPadding ->
     NavHost(
       modifier = Modifier


### PR DESCRIPTION
## Description

Currently edge to edge is enabled but we are not making use of safe insets which causes app to draw behind display cutouts. This is not a good UX, especially in landscape mode.

Reference: https://developer.android.com/develop/ui/compose/layouts/insets

## Screenshots

Before
<img width="708" alt="Screenshot 2024-11-23 at 01 06 15" src="https://github.com/user-attachments/assets/e5d1d8e9-61a4-44d0-a101-79a566c6a4f5">

After
<img width="697" alt="Screenshot 2024-11-23 at 01 07 06" src="https://github.com/user-attachments/assets/fbb55ea2-651d-4ecf-abc5-78efe5e185e8">

