### PR TITLE
Adding Paging for Feeds

### DIFF
--- a/ios/HackerNews.xcodeproj/project.pbxproj
+++ b/ios/HackerNews.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		EC072CAA2CEF02A500D00B8D /* StoryRowV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC072CA92CEF02A500D00B8D /* StoryRowV2.swift */; };
 		EC29FDA72CFFD074007B1AE9 /* BookmarksScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC29FDA62CFFD074007B1AE9 /* BookmarksScreen.swift */; };
 		EC29FDA92CFFD0B5007B1AE9 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC29FDA82CFFD0B5007B1AE9 /* SettingsScreen.swift */; };
+		ECCE8F262D03815300349733 /* Pager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCE8F252D03815300349733 /* Pager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,6 +143,7 @@
 		EC072CA92CEF02A500D00B8D /* StoryRowV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryRowV2.swift; sourceTree = "<group>"; };
 		EC29FDA62CFFD074007B1AE9 /* BookmarksScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksScreen.swift; sourceTree = "<group>"; };
 		EC29FDA82CFFD0B5007B1AE9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		ECCE8F252D03815300349733 /* Pager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +200,7 @@
 				A413E8562A8C40E800C0F867 /* Extensions.swift */,
 				A423B0692BAE061600267DDB /* Flags.swift */,
 				A40DC1F92C20D8B60055B920 /* Previews.swift */,
+				ECCE8F252D03815300349733 /* Pager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -585,6 +588,7 @@
 				A42705A72A42949D0057E439 /* AppViewModel.swift in Sources */,
 				A42705AD2A429D2E0057E439 /* HNApi.swift in Sources */,
 				A423B0682BAE05FB00267DDB /* NetworkDebugger.swift in Sources */,
+				ECCE8F262D03815300349733 /* Pager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/HackerNews/Components/StoryRow.swift
+++ b/ios/HackerNews/Components/StoryRow.swift
@@ -10,42 +10,47 @@ import SwiftUI
 
 struct StoryRow: View {
   @ObservedObject var model: AppViewModel
-  let story: Story
+  let state: StoryState
   
   var body: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      let author = story.by!
-      Text("@\(author)")
-        .foregroundColor(.hnOrange)
-        .fontWeight(/*@START_MENU_TOKEN@*/.bold/*@END_MENU_TOKEN@*/)
-      Text(story.title)
-        .font(.headline)
-      HStack(spacing: 16) {
-        HStack(spacing: 4) {
-          Image(systemName: "arrow.up")
-            .foregroundColor(.green)
-          Text("\(story.score)")
-        }
-        HStack(spacing: 4) {
-          Image(systemName: "clock")
-            .foregroundColor(.purple)
-          Text(story.displayableDate)
-        }
-        Spacer()
-        // Comment Button
-        Button(action: {
-          print("Pressed comment button for: \(story.id)")
-          model.navigationPath.append(
-            AppViewModel.AppNavigation.storyComments(story: story)
-          )
-        }) {
+    switch state {
+    case .loading:
+      ProgressView()
+    case .loaded(let story):
+      VStack(alignment: .leading, spacing: 8) {
+        let author = story.by!
+        Text("@\(author)")
+          .foregroundColor(.hnOrange)
+          .fontWeight(/*@START_MENU_TOKEN@*/.bold/*@END_MENU_TOKEN@*/)
+        Text(story.title)
+          .font(.headline)
+        HStack(spacing: 16) {
           HStack(spacing: 4) {
-            Image(systemName: "message.fill")
-            Text("\(story.commentCount)")
+            Image(systemName: "arrow.up")
+              .foregroundColor(.green)
+            Text("\(story.score)")
           }
+          HStack(spacing: 4) {
+            Image(systemName: "clock")
+              .foregroundColor(.purple)
+            Text(story.displayableDate)
+          }
+          Spacer()
+          // Comment Button
+          Button(action: {
+            print("Pressed comment button for: \(story.id)")
+            model.navigationPath.append(
+              AppViewModel.AppNavigation.storyComments(story: story)
+            )
+          }) {
+            HStack(spacing: 4) {
+              Image(systemName: "message.fill")
+              Text("\(story.commentCount)")
+            }
+          }
+          .buttonStyle(.bordered)
+          .buttonBorderShape(ButtonBorderShape.capsule)
         }
-        .buttonStyle(.bordered)
-        .buttonBorderShape(ButtonBorderShape.capsule)
       }
     }
   }
@@ -55,7 +60,7 @@ struct StoryRow_Preview: PreviewProvider {
   static var previews: some View {
     let fakeStory = PreviewHelpers.makeFakeStory(index: 0, descendants: 3, kids: [1, 2, 3])
     PreviewVariants {
-      StoryRow(model: AppViewModel(), story: fakeStory)
+      StoryRow(model: AppViewModel(), state: .loaded(story: fakeStory))
     }
   }
 }

--- a/ios/HackerNews/Components/StoryRow.swift
+++ b/ios/HackerNews/Components/StoryRow.swift
@@ -16,6 +16,18 @@ struct StoryRow: View {
     switch state {
     case .loading:
       ProgressView()
+    case .nextPage:
+      HStack {
+        Spacer()
+        Text("Loading Next Page")
+        ProgressView()
+        Spacer()
+      }
+      .onAppear {
+        Task {
+          await model.fetchNextPage()
+        }
+      }
     case .loaded(let story):
       VStack(alignment: .leading, spacing: 8) {
         let author = story.by!

--- a/ios/HackerNews/Components/StoryRow.swift
+++ b/ios/HackerNews/Components/StoryRow.swift
@@ -19,7 +19,6 @@ struct StoryRow: View {
     case .nextPage:
       HStack {
         Spacer()
-        Text("Loading Next Page")
         ProgressView()
         Spacer()
       }

--- a/ios/HackerNews/ContentView.swift
+++ b/ios/HackerNews/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView_LoggedIn_Loading_Previews: PreviewProvider {
   static var previews: some View {
     let appModel = AppViewModel()
     appModel.authState = .loggedIn
-    appModel.postListState = PostListState(storiesState: .loading)
+    appModel.postListState = PostListState(stories: [])
     return PreviewVariants {
       PreviewHelpers.withNavigationView {
         ContentView(appState: appModel)
@@ -60,10 +60,13 @@ struct ContentView_LoggedIn_Loading_Previews: PreviewProvider {
 struct ContentView_LoggedIn_WithPosts_Previews: PreviewProvider {
   static var previews: some View {
     let appModel = AppViewModel()
+    let fakeStories = PreviewHelpers
+      .makeFakeStories()
+      .map { StoryState.loaded(story: $0) }
+    
     appModel.authState = .loggedIn
-    appModel.postListState = PostListState(
-      storiesState: .loaded(items: PreviewHelpers.makeFakeStories())
-    )
+    appModel.postListState = PostListState(stories: fakeStories)
+    
     return PreviewVariants {
       PreviewHelpers.withNavigationView {
         ContentView(appState: appModel)
@@ -76,9 +79,7 @@ struct ContentView_LoggedIn_EmptyPosts_Previews: PreviewProvider {
   static var previews: some View {
     let appModel = AppViewModel()
     appModel.authState = .loggedIn
-    appModel.postListState = PostListState(
-      storiesState: .loaded(items: [])
-    )
+    appModel.postListState = PostListState(stories: [])
     return PreviewVariants {
       PreviewHelpers.withNavigationView {
         ContentView(appState: appModel)

--- a/ios/HackerNews/Models/AppViewModel.swift
+++ b/ios/HackerNews/Models/AppViewModel.swift
@@ -37,10 +37,30 @@ enum StoriesState {
   case loaded(items: [Story])
 }
 
+/**
+ Display State
+ needs information for the feed selection
+ needs a list of Stories for the feed
+ the feed items can have their own loading state
+ */
 struct PostListState {
   var feeds: [FeedType] = FeedType.allCases
-  var storiesState: StoriesState = .notStarted
   var selectedFeed: FeedType = FeedType.top
+  var stories: [StoryState] = []
+}
+
+enum StoryState: Identifiable {
+  case loading(id: Int64)
+  case loaded(story: Story)
+  
+  var id: Int64 {
+    switch self {
+    case .loading(id: let id):
+      return id
+    case .loaded(story: let story):
+      return story.id
+    }
+  }
 }
 
 @MainActor
@@ -76,11 +96,10 @@ class AppViewModel: ObservableObject {
   func fetchPosts(feedType: FeedType) async {
     var updated = postListState
     updated.selectedFeed = feedType
-    updated.storiesState = .loading
+    updated.stories = []
     postListState = updated
     
-    let stories = await hnApi.fetchStories(feedType: feedType)
-    updated.storiesState = .loaded(items: stories)
-    postListState = updated
+    let storyIds = await hnApi.fetchStories(feedType: feedType)
+    print("Loading Feed: \(feedType) with ids \(storyIds)")
   }
 }

--- a/ios/HackerNews/Models/AppViewModel.swift
+++ b/ios/HackerNews/Models/AppViewModel.swift
@@ -14,7 +14,7 @@ enum FeedType: CaseIterable {
   case best
   case ask
   case show
-  
+
   var title: String {
     switch self {
     case .top:
@@ -46,7 +46,7 @@ struct PostListState {
 enum StoryState: Identifiable {
   case loading(id: Int64)
   case loaded(story: Story)
-  
+
   var id: Int64 {
     switch self {
     case .loading(id: let id):
@@ -59,59 +59,47 @@ enum StoryState: Identifiable {
 
 @MainActor
 class AppViewModel: ObservableObject {
-  
+
   enum AppNavigation: Codable, Hashable {
     case webLink(url: URL, title: String)
     case storyComments(story: Story)
   }
-  
+
   enum AuthState {
     case loggedIn
     case loggedOut
   }
-  
+
   @Published var authState = AuthState.loggedOut
   @Published var postListState = PostListState()
   @Published var navigationPath = NavigationPath()
-  
+
   private let hnApi = HNApi()
-  private let pageSize = 20
-  private var idsToConsume: [Int64] = []
+  private var pager = Pager()
   
   init() {}
-  
+
   func performLogin() {
     authState = .loggedIn
   }
-  
+
   func performLogout() {
     authState = .loggedOut
   }
-  
+
   func fetchPosts(feedType: FeedType) async {
     postListState.selectedFeed = feedType
     postListState.stories = []
-    idsToConsume = []
-    
-    idsToConsume = await hnApi.fetchStories(feedType: feedType)
-    print("Feed Items Size: \(idsToConsume.count)")
-    let nextPageIds = Array(idsToConsume[0..<pageSize])
-    idsToConsume.removeFirst(pageSize)
-    
-    print("Page Size: \(nextPageIds.count)")
 
-    postListState.stories += nextPageIds.map { StoryState.loading(id: $0) }
-    
-    // load the page
-    let page = Page(ids: nextPageIds)
-    let items = await hnApi.fetchPage(page: page)
-    postListState.stories = postListState.stories.map { state in
-      let updated = items.first { $0.id == state.id }
-      if (updated != nil && updated!.type == .story) {
-        return .loaded(story: updated as! Story)
-      } else {
-        return state
-      }
+    let idsToConsume = await hnApi.fetchStories(feedType: feedType)
+    pager.setIds(idsToConsume)
+
+    if pager.hasNextPage() {
+      let nextPage = pager.nextPage()
+      postListState.stories = nextPage.ids.map { StoryState.loading(id: $0) }
+
+      let items = await hnApi.fetchPage(page: nextPage)
+      postListState.stories = items.map { StoryState.loaded(story: $0 as! Story) }
     }
   }
 }

--- a/ios/HackerNews/Network/HNApi.swift
+++ b/ios/HackerNews/Network/HNApi.swift
@@ -14,7 +14,9 @@ class HNApi {
   
   init() {}
   
-  func fetchStories(feedType: FeedType) async -> [Story] {
+  
+  
+  func fetchStories(feedType: FeedType) async -> [Int64] {
     NotificationCenter.default.post(name: Notification.Name(rawValue: "EmergeMetricStarted"), object: nil, userInfo: [
       "metric": "FETCH_STORIES"
     ])
@@ -39,13 +41,13 @@ class HNApi {
       if Flags.isEnabled(.networkDebugger) {
         NetworkDebugger.printStats(for: response)
       }
+      
       let storyIds = try decoder.decode([Int64].self, from: data)
-      let items = await fetchItems(ids: Array(storyIds.prefix(20)))
-
+      
       NotificationCenter.default.post(name: Notification.Name(rawValue: "EmergeMetricEnded"), object: nil, userInfo: [
         "metric": "FETCH_STORIES"
       ])
-      return items.compactMap { $0 as? Story }
+      return storyIds
     } catch {
       print("Error fetching post IDs: \(error)")
       return []

--- a/ios/HackerNews/Network/HNApi.swift
+++ b/ios/HackerNews/Network/HNApi.swift
@@ -55,7 +55,7 @@ class HNApi {
     }
   }
   
-  func fetchPage(page: Page) async -> [HNItem] {
+  func fetchPage(page: Page) async -> [Story] {
     do {
       return try await withThrowingTaskGroup(of: HNItem.self) { taskGroup in
         for id in page.ids {
@@ -87,7 +87,7 @@ class HNApi {
         for try await result in taskGroup {
           idToItem[result.id] = result
         }
-        return page.ids.compactMap { idToItem[$0] }
+        return page.ids.compactMap { idToItem[$0] as? Story }
       }
     } catch let error {
       print("Error loading page: \(error)")

--- a/ios/HackerNews/Network/HNApi.swift
+++ b/ios/HackerNews/Network/HNApi.swift
@@ -7,9 +7,6 @@
 
 import Foundation
 
-struct Page {
-  var ids: [Int64]
-}
 
 class HNApi {
   

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -23,7 +23,7 @@ struct LoginScreen: View {
       Button("Login") {
         appState.performLogin()
         Task {
-          await appState.fetchPosts(feedType: .top)
+          await appState.fetchInitialPosts(feedType: .top)
         }
       }
       .buttonStyle(ThemedButtonStyle())

--- a/ios/HackerNews/Screens/PostListScreen.swift
+++ b/ios/HackerNews/Screens/PostListScreen.swift
@@ -14,6 +14,7 @@ struct PostListScreen: View {
   
   var body: some View {
     VStack {
+      // Feed Selection
       HStack(spacing: 16) {
         ForEach(appState.postListState.feeds, id: \.self) { feedType in
           Button(action: {
@@ -29,63 +30,34 @@ struct PostListScreen: View {
         }
       }
       .padding(16)
-      switch appState.postListState.storiesState {
-      case .notStarted, .loading:
-        ProgressView()
-          .progressViewStyle(CircularProgressViewStyle())
-          .scaleEffect(2)
-          .frame(maxHeight: .infinity)
-      case .loaded(let items):
-        TabView(selection: .constant(0)) {
-          List(items, id: \.id) { story in
-            let navigationValue: AppViewModel.AppNavigation = {
-              if let url = story.makeUrl() {
-                return AppViewModel.AppNavigation.webLink(url: url, title: story.title)
-              } else {
-                return AppViewModel.AppNavigation.storyComments(story: story)
-              }
-            }()
-            
-            StoryRow(
-              model: appState,
-              story: story
-            )
-            .background(
-              NavigationLink(
-                value: navigationValue,
-                label: {}
-              )
-              .opacity(0.0)
-            )
-            .listRowBackground(Color.clear)
-          }
-          .tag(0)
-          .listStyle(.plain)
-        }
-        .tabViewStyle(.page)
-      }
-    }
-//    .navigationBarTitle("Hacker News")
-//    .toolbar {
-//      ToolbarItemGroup(placement: .navigationBarTrailing) {
-//        Button(action: {
-//          Task {
-//            await appState.fetchPosts(feedType: .top)
+      
+      // Feed Items
+      List(appState.postListState.stories, id: \.id) { storyState in
+//        let navigationValue: AppViewModel.AppNavigation = {
+//          if let url = story.makeUrl() {
+//            return AppViewModel.AppNavigation.webLink(url: url, title: story.title)
+//          } else {
+//            return AppViewModel.AppNavigation.storyComments(story: story)
 //          }
-//        }) {
-//          Image(systemName: "arrow.counterclockwise")
-//            .foregroundColor(.white)
-//        }
-//        Button(action: {
-//          appState.performLogout()
-//        }) {
-//          Image(systemName: "rectangle.portrait.and.arrow.right")
-//            .foregroundColor(.white)
-//        }
-//      }
-//    }
+//        }()
+        
+        StoryRow(
+          model: appState,
+          state: storyState
+        )
+//        .background(
+//          NavigationLink(
+//            value: navigationValue,
+//            label: {}
+//          )
+//          .opacity(0.0)
+//        )
+        .listRowBackground(Color.clear)
+      }
+      .tag(0)
+      .listStyle(.plain)
+    }
   }
-  
 }
 
 #Preview {
@@ -95,13 +67,18 @@ struct PostListScreen: View {
 #Preview("Loading") {
   let appModel = AppViewModel()
   appModel.authState = .loggedIn
-  appModel.postListState = PostListState(storiesState: .loading)
+  appModel.postListState = PostListState()
+  
   return PostListScreen(appState: appModel)
 }
 
 #Preview("Has posts") {
   let appModel = AppViewModel()
+  let fakeStories = PreviewHelpers
+    .makeFakeStories()
+    .map { StoryState.loaded(story: $0) }
   appModel.authState = .loggedIn
-  appModel.postListState = PostListState(storiesState: .loaded(items: PreviewHelpers.makeFakeStories()))
+  appModel.postListState = PostListState(stories: fakeStories)
+  
   return PostListScreen(appState: appModel)
 }

--- a/ios/HackerNews/Screens/PostListScreen.swift
+++ b/ios/HackerNews/Screens/PostListScreen.swift
@@ -14,7 +14,6 @@ struct PostListScreen: View {
   
   var body: some View {
     VStack {
-      // Feed Selection
       HStack(spacing: 16) {
         ForEach(appState.postListState.feeds, id: \.self) { feedType in
           Button(action: {
@@ -31,27 +30,28 @@ struct PostListScreen: View {
       }
       .padding(16)
       
-      // Feed Items
       List(appState.postListState.stories, id: \.id) { storyState in
-//        let navigationValue: AppViewModel.AppNavigation = {
-//          if let url = story.makeUrl() {
-//            return AppViewModel.AppNavigation.webLink(url: url, title: story.title)
-//          } else {
-//            return AppViewModel.AppNavigation.storyComments(story: story)
-//          }
-//        }()
-        
         StoryRow(
           model: appState,
           state: storyState
         )
-//        .background(
-//          NavigationLink(
-//            value: navigationValue,
-//            label: {}
-//          )
-//          .opacity(0.0)
-//        )
+        .background {
+          switch storyState {
+          case .loading, .nextPage:
+            EmptyView()
+          case .loaded(let story):
+            let destination: AppViewModel.AppNavigation = if let url = story.makeUrl() {
+              .webLink(url: url, title: story.title)
+            } else {
+              .storyComments(story: story)
+            }
+            NavigationLink(
+              value: destination,
+              label: {}
+            )
+            .opacity(0.0)
+          }
+        }
         .listRowBackground(Color.clear)
       }
       .tag(0)

--- a/ios/HackerNews/Screens/PostListScreen.swift
+++ b/ios/HackerNews/Screens/PostListScreen.swift
@@ -19,7 +19,7 @@ struct PostListScreen: View {
         ForEach(appState.postListState.feeds, id: \.self) { feedType in
           Button(action: {
             Task {
-              await appState.fetchPosts(feedType: feedType)
+              await appState.fetchInitialPosts(feedType: feedType)
             }
           }) {
             Text(feedType.title)

--- a/ios/HackerNews/Screens/PostListScreen.swift
+++ b/ios/HackerNews/Screens/PostListScreen.swift
@@ -28,7 +28,7 @@ struct PostListScreen: View {
           }
         }
       }
-      .padding(16)
+      .padding(8)
       
       List(appState.postListState.stories, id: \.id) { storyState in
         StoryRow(
@@ -57,6 +57,8 @@ struct PostListScreen: View {
       .tag(0)
       .listStyle(.plain)
     }
+    .navigationTitle("")
+    .navigationBarHidden(true)
   }
 }
 

--- a/ios/HackerNews/Utils/Pager.swift
+++ b/ios/HackerNews/Utils/Pager.swift
@@ -1,0 +1,36 @@
+//
+//  Pager.swift
+//  HackerNews
+//
+//  Created by Rikin Marfatia on 12/6/24.
+//
+
+import Foundation
+
+struct Page {
+  var ids: ArraySlice<Int64>
+}
+
+struct Pager {
+  private var ids: [Int64] = []
+  private let pageSize: Int = 20
+  
+  mutating func setIds(_ ids: [Int64]) {
+    self.ids = ids
+  }
+  
+  mutating func nextPage() -> Page {
+    // first see if we can slice of the next page size
+    let pageCount = min(ids.count, pageSize)
+    
+    // remove items from array
+    let taken = ids.prefix(pageCount)
+    ids.removeFirst(pageCount)
+    
+    return Page(ids: taken)
+  }
+  
+  func hasNextPage() -> Bool {
+    return !ids.isEmpty
+  }
+}

--- a/ios/HackerNewsTests/SwiftSnapshotTest.swift
+++ b/ios/HackerNewsTests/SwiftSnapshotTest.swift
@@ -63,7 +63,7 @@ final class SwiftSnapshotTest: XCTestCase {
     let loadingViewModel = AppViewModel()
     loadingViewModel.authState = .loggedIn
     loadingViewModel.postListState = PostListState(
-      storiesState: .loading
+      stories: []
     )
     let loadingView = PostListScreen(appState: loadingViewModel)
 
@@ -71,9 +71,7 @@ final class SwiftSnapshotTest: XCTestCase {
     let loadedViewModel = AppViewModel()
     loadedViewModel.authState = .loggedIn
     loadedViewModel.postListState = PostListState(
-      storiesState: .loaded(
-        items: PreviewHelpers.makeFakeStories()
-      )
+      stories: PreviewHelpers.makeFakeStories().map { StoryState.loaded(story: $0) }
     )
     let loadedView = PostListScreen(appState: loadedViewModel)
 


### PR DESCRIPTION
I built a simple system similar to Android to support paging. We get the full list of Ids for a feed, and just feed it into a lil helper struct that will chunk it into pages we can request. Once a page is loaded fully we return the page of items.

The mechanism for paging is a "marker view" that triggers the viewmodel to load the next page.