### PR TITLE
Login + Cookie Management

### DIFF
--- a/ios/HackerNews/ContentView.swift
+++ b/ios/HackerNews/ContentView.swift
@@ -44,9 +44,10 @@ struct ContentView_LoggedIn_WithPosts_Previews: PreviewProvider {
     let fakeStories = PreviewHelpers
       .makeFakeStories()
       .map { StoryState.loaded(story: $0) }
-
+    
+    appModel.authState = .loggedIn
     appModel.postListState = PostListState(stories: fakeStories)
-
+    
     return PreviewVariants {
       PreviewHelpers.withNavigationView {
         ContentView(model: appModel)

--- a/ios/HackerNews/HNApp.swift
+++ b/ios/HackerNews/HNApp.swift
@@ -62,4 +62,8 @@ struct Hacker_NewsApp: App {
       }
     }
   }
+
+  func isLoggedIn() -> AuthState {
+    return HTTPCookieStorage.shared.cookies?.isEmpty == true ? .loggedOut : .loggedIn
+  }
 }

--- a/ios/HackerNews/Models/AppViewModel.swift
+++ b/ios/HackerNews/Models/AppViewModel.swift
@@ -73,8 +73,8 @@ class AppViewModel: ObservableObject {
     case storyComments(story: Story)
   }
 
-  @Published var showLoginSheet: Bool
-  @Published var authState: AuthState = .loggedOut
+  @Published var authState: AuthState
+  @Published var showLoginSheet: Bool = false
   @Published var postListState = PostListState()
   @Published var navigationPath = NavigationPath()
 
@@ -83,8 +83,8 @@ class AppViewModel: ObservableObject {
   private var pager = Pager()
   private let cookieStorage = HTTPCookieStorage.shared
 
-  init(showLogin: Bool = false) {
-    self.showLoginSheet = showLogin
+  init() {
+    authState = self.cookieStorage.cookies?.isEmpty == true ? .loggedOut : .loggedIn
   }
 
   func fetchInitialPosts(feedType: FeedType) async {
@@ -123,6 +123,7 @@ class AppViewModel: ObservableObject {
     if (authState == .loggedOut) {
       showLoginSheet = true
     } else {
+      cookieStorage.removeCookies()
       authState = .loggedOut
     }
   }

--- a/ios/HackerNews/Models/StoryViewModel.swift
+++ b/ios/HackerNews/Models/StoryViewModel.swift
@@ -62,10 +62,8 @@ class StoryViewModel: ObservableObject {
   }
 
   func likeComment(comment: CommentInfo) async {
-    print("DEBUG: like comment clicked for \(comment.id)")
     if (isLoggedIn()) {
       let success = await webClient.upvoteItem(upvoteUrl: comment.upvoteUrl!)
-      print("DEBUG: upvoted comment \(success)")
     } else {
       // navigate to login modal
     }

--- a/ios/HackerNews/Network/HNWebClient.swift
+++ b/ios/HackerNews/Network/HNWebClient.swift
@@ -118,3 +118,9 @@ extension HTTPURLResponse {
     return statusCode >= 200 && statusCode < 300
   }
 }
+
+extension HTTPCookieStorage {
+  func removeCookies() {
+    self.removeCookies(since: Date(timeIntervalSince1970: 0))
+  }
+}

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -21,6 +21,8 @@ enum LoginStatus {
 }
 
 struct LoginScreen: View {
+  @State var username: String = ""
+  @State var password: String = ""
   @ObservedObject var model: AppViewModel
 
   var body: some View {

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -26,21 +26,38 @@ struct LoginScreen: View {
   @ObservedObject var model: AppViewModel
 
   var body: some View {
-    List {
-      TextField(text: $model.loginState.username) {
-        Text("Username")
-      }
-      .autocapitalization(.none)
-      SecureField(text: $model.loginState.password) {
-        Text("Password")
-      }
-      .autocapitalization(.none)
-      Button("Login") {
-        Task {
-          await model.login()
+    VStack(spacing: 8) {
+      TextField("Username", text: $model.loginState.username)
+        .padding()
+        .overlay(
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.secondary.opacity(0.5))
+        )
+        .autocapitalization(.none)
+
+      SecureField("Password", text: $model.loginState.password)
+        .padding()
+        .overlay(
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.secondary.opacity(0.5))
+        )
+
+      Button(
+        action: {
+          Task {
+            await model.login()
+          }
+        },
+        label: {
+          Text("Login")
+            .padding(8)
         }
-      }
+      )
+      .buttonStyle(.borderedProminent)
+      .buttonBorderShape(.capsule)
+      .disabled(model.loginState.username.isEmpty || model.loginState.password.isEmpty)
     }
+    .padding(16)
   }
 }
 

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -19,8 +19,6 @@ enum LoginStatus {
 }
 
 struct LoginScreen: View {
-  @State var username: String = ""
-  @State var password: String = ""
   @ObservedObject var model: AppViewModel
   @State var loginState = LoginState()
 

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -27,20 +27,23 @@ struct LoginScreen: View {
 
   var body: some View {
     VStack(spacing: 8) {
+
+      Image(systemName: "bolt.horizontal.circle.fill")
+        .foregroundStyle(HNColors.orange)
+        .font(.system(size: 64))
+
+      Spacer()
+        .frame(maxHeight: 16)
+
       TextField("Username", text: $model.loginState.username)
-        .padding()
-        .overlay(
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.secondary.opacity(0.5))
-        )
+        .textFieldStyle(.roundedBorder)
         .autocapitalization(.none)
 
       SecureField("Password", text: $model.loginState.password)
-        .padding()
-        .overlay(
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.secondary.opacity(0.5))
-        )
+        .textFieldStyle(.roundedBorder)
+
+      Spacer()
+        .frame(maxHeight: 16)
 
       Button(
         action: {
@@ -50,14 +53,15 @@ struct LoginScreen: View {
         },
         label: {
           Text("Login")
-            .padding(8)
+            .frame(maxWidth: .infinity)
         }
       )
       .buttonStyle(.borderedProminent)
-      .buttonBorderShape(.capsule)
       .disabled(model.loginState.username.isEmpty || model.loginState.password.isEmpty)
     }
-    .padding(16)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(32)
+    .background(HNColors.background)
   }
 }
 

--- a/ios/HackerNews/Screens/LoginScreen.swift
+++ b/ios/HackerNews/Screens/LoginScreen.swift
@@ -11,11 +11,9 @@ import SwiftUI
 struct LoginState {
   var username: String = ""
   var password: String = ""
-  var status: LoginStatus = .uninitialized
 }
 
 enum LoginStatus {
-  case uninitialized
   case error
   case success
 }
@@ -24,6 +22,7 @@ struct LoginScreen: View {
   @State var username: String = ""
   @State var password: String = ""
   @ObservedObject var model: AppViewModel
+  @State var loginState = LoginState()
 
   var body: some View {
     VStack(spacing: 8) {
@@ -35,11 +34,11 @@ struct LoginScreen: View {
       Spacer()
         .frame(maxHeight: 16)
 
-      TextField("Username", text: $model.loginState.username)
+      TextField("Username", text: $loginState.username)
         .textFieldStyle(.roundedBorder)
         .autocapitalization(.none)
 
-      SecureField("Password", text: $model.loginState.password)
+      SecureField("Password", text: $loginState.password)
         .textFieldStyle(.roundedBorder)
 
       Spacer()
@@ -48,7 +47,10 @@ struct LoginScreen: View {
       Button(
         action: {
           Task {
-            await model.login()
+            await model.loginTapped(
+              username: loginState.username,
+              password: loginState.password
+            )
           }
         },
         label: {
@@ -57,7 +59,7 @@ struct LoginScreen: View {
         }
       )
       .buttonStyle(.borderedProminent)
-      .disabled(model.loginState.username.isEmpty || model.loginState.password.isEmpty)
+      .disabled(loginState.username.isEmpty || loginState.password.isEmpty)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .padding(32)

--- a/ios/HackerNews/Screens/SettingsScreen.swift
+++ b/ios/HackerNews/Screens/SettingsScreen.swift
@@ -18,6 +18,13 @@ struct SettingsScreen: View {
           .fill(model.authState == AuthState.loggedIn ? Color.green : Color.red)
           .frame(width: 6)
         Text(model.authState == AuthState.loggedIn ? "Logout" : "Login")
+        Spacer()
+        Image(systemName: "message.fill")
+          .font(.system(size: 12))
+          .foregroundStyle(model.authState == AuthState.loggedIn ? Color.blue : Color.gray)
+        Image(systemName: "arrow.up")
+          .font(.system(size: 12))
+          .foregroundStyle(model.authState == AuthState.loggedIn ? Color.green : Color.gray)
       }
       .onTapGesture {
         model.loginRowTapped()

--- a/ios/HackerNews/Screens/SettingsScreen.swift
+++ b/ios/HackerNews/Screens/SettingsScreen.swift
@@ -10,17 +10,21 @@ import SwiftUI
 
 struct SettingsScreen: View {
   @ObservedObject var model: AppViewModel
-  @State var shouldPresentSheet = false
+
   var body: some View {
     List {
       HStack {
-        Text("Login")
+        Circle()
+          .fill(model.authState == AuthState.loggedIn ? Color.green : Color.red)
+          .frame(width: 6)
+        Text(model.authState == AuthState.loggedIn ? "Logout" : "Login")
       }
       .onTapGesture {
-        shouldPresentSheet.toggle()
+        model.loginRowTapped()
       }
     }
-    .sheet(isPresented: $shouldPresentSheet) {
+    .navigationTitle("Settings")
+    .sheet(isPresented: $model.showLoginSheet) {
       LoginScreen(model: model)
     }
   }


### PR DESCRIPTION
Removed old Login Setup, and added some new stuff:
- Basic Login Sheet
- Login Endpoint that sends a Post Request and stores the auth cookie
- Simple Settings Page with an entrypoint to Login