### PR TITLE
[iOS][UI] Improve StoryRow tappable area

### DIFF
--- a/ios/HackerNews/Stories/StoryRow.swift
+++ b/ios/HackerNews/Stories/StoryRow.swift
@@ -147,6 +147,7 @@ struct StoryRowLoadingState: View {
 private struct StoryRowButtonStyle: ButtonStyle {
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
+      .contentShape(Rectangle())
       .background(Color.gray.opacity(configuration.isPressed ? 0.1 : 0))
       .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
       .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)


### PR DESCRIPTION
## What 

- Ensure the whole `StoryRow` is tappable, instead of only allowing the user to tap on the frame of its subviews

### Before

- Only able to tap on the subviews of the `StoryRow`, many tap misses, creating a sense of unresponsiveness to the interaction

https://github.com/user-attachments/assets/1f9b9dab-e524-4969-8ad7-184d6f713c7e

### After

- The whole `StoryRow` is tappable

https://github.com/user-attachments/assets/0261d166-7056-4c82-b7d4-79bcbfc3c6db



