### PR TITLE
[iOS][UX] Add interactive pop gesture to SwiftUI's NavigationStack

### DIFF
--- a/ios/HackerNews/Utils/Extensions.swift
+++ b/ios/HackerNews/Utils/Extensions.swift
@@ -7,6 +7,23 @@
 
 import Foundation
 import SwiftSoup
+import UIKit
+
+/// This code provides a workaround to enable the interactive pop gesture in NavigationStacks in SwiftUI.
+/// While not the most elegant or ideal solution, it significantly enhances the navigation user experience.
+///
+/// Note: This is intended as a temporary fix and should be removed once Apple adds proper support
+/// for interactive pop gestures in NavigationStacks. Please refer to PR #TBD for more details.
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+  override open func viewDidLoad() {
+    super.viewDidLoad()
+    interactivePopGestureRecognizer?.delegate = self
+  }
+
+  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    return viewControllers.count > 1
+  }
+}
 
 extension String {
   func strippingHTML() -> String {


### PR DESCRIPTION
## What

- Implement a workaround to add the (much appreciated) interactive pop gesture to SwiftUI's NavigationStack until Apple doesn't provide proper support for it.

### Before

- No interactive pop gesture 😢 

https://github.com/user-attachments/assets/b9ac81fc-370e-489c-a844-316928d32d39

### After

- Interactive pop gesture 🚀 

https://github.com/user-attachments/assets/52136b7e-0076-4295-90b4-9762a1674a3f

