### PR TITLE
Apply room gradle plugin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.emerge)
   alias(libs.plugins.sentry)
   alias(libs.plugins.roborazzi)
+  alias(libs.plugins.androidx.room)
 }
 
 val runningEnv: String? = System.getenv("RUNNING_ENV")
@@ -89,10 +90,13 @@ android {
       isIncludeAndroidResources = true
     }
   }
+  room {
+    schemaDirectory("$projectDir/schemas")
+  }
 }
 
-composeCompiler {
-  enableStrongSkippingMode = true
+ksp {
+  arg("room.generateKotlin", "true")
 }
 
 emerge {

--- a/android/app/schemas/com.emergetools.hackernews.data.local.HackerNewsDatabase/1.json
+++ b/android/app/schemas/com.emergetools.hackernews.data.local.HackerNewsDatabase/1.json
@@ -1,0 +1,76 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "bf776bd286b171f45077312ad4800d73",
+    "entities": [
+      {
+        "tableName": "bookmark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `score` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `url` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bf776bd286b171f45077312ad4800d73')"
+    ]
+  }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,4 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.kotlin.ksp) apply false
   alias(libs.plugins.roborazzi) apply false
+  alias(libs.plugins.androidx.room) apply false
+  alias(libs.plugins.sentry) apply false
+  alias(libs.plugins.emerge) apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,7 +20,6 @@ org.gradle.configuration-cache.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
+
+android.defaults.buildfeatures.resvalues=false
+android.defaults.buildfeatures.shaders=false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -82,5 +82,5 @@ kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 emerge = { id = "com.emergetools.android", version.ref = "emergePlugin" }
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
-
+androidx-room = { id = "androidx.room", version.ref = "room" }
 


### PR DESCRIPTION
This will generate the database schema in a build caching compatible way.
This also generates the database code in Kotlin to save java
compilation.

Clean up buildscript classpath.
Remove deprecated flag which is now enabled by default.
