### PR TITLE
Remove Emerge Plugin application

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -8,5 +8,4 @@ plugins {
   alias(libs.plugins.roborazzi) apply false
   alias(libs.plugins.androidx.room) apply false
   alias(libs.plugins.sentry) apply false
-  alias(libs.plugins.emerge) apply false
 }


### PR DESCRIPTION
This should fix the integration test errors like this one: https://github.com/EmergeTools/emerge-android/actions/runs/13502089290/job/37722785622?pr=471#step:6:44
