### PR TITLE
chore: Enable Sentry appHangTracking V2

### DIFF
--- a/ios/HackerNews.xcodeproj/project.pbxproj
+++ b/ios/HackerNews.xcodeproj/project.pbxproj
@@ -1202,7 +1202,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.49.0;
+				minimumVersion = 8.50.1;
 			};
 		};
 		A47309B22AA29D9600201376 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/ios/HackerNews.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/HackerNews.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4b58aaae91f42ea86fa0fac797fe609228b1691199ca61682723c382b821da6a",
+  "originHash" : "c34323d163c00dd4dae2ae6fc2f9a080d25b045754f0da0c9fb74617d5640494",
   "pins" : [
     {
       "identity" : "accessibilitysnapshot",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "2c6c1b81d9f6e6178064b4e9b457abe1c118bcda",
-        "version" : "8.49.0"
+        "revision" : "6c81e671154e63464dd6749b7ba3279dd390a146",
+        "version" : "8.50.1"
       }
     },
     {

--- a/ios/HackerNews/HNApp.swift
+++ b/ios/HackerNews/HNApp.swift
@@ -35,6 +35,7 @@ struct HackerNewsApp: App {
           print("Failed to submit feedback: \(error)")
         }
       }
+      options.enableAppHangTrackingV2 = true
     }
   }
 


### PR DESCRIPTION
Enable the appHangTrackingV2 and update Sentry from 8.49.0 to 8.50.1.

AppHangsV2 is more powerful and it would be great to see some data coming in from the Hackernews app. For more info see: https://docs.sentry.io/platforms/apple/guides/ios/configuration/app-hangs/#app-hangs-v2.