### PR TITLE
Adjust spacing in the Feed header

### DIFF
--- a/ios/HackerNews/Feed/FeedScreen.swift
+++ b/ios/HackerNews/Feed/FeedScreen.swift
@@ -23,7 +23,7 @@ struct FeedScreen: View {
           .containerShape(.rect(cornerRadius: 24, style: .continuous))
 
         HStack(spacing: 16) {
-          Spacer()
+          Spacer(minLength: 0)
           ForEach(model.feedState.feeds, id: \.self) { feedType in
             Button(action: {
               withAnimation {
@@ -40,7 +40,7 @@ struct FeedScreen: View {
             }
             .frame(maxWidth: .infinity)
           }
-          Spacer()
+          Spacer(minLength: 0)
         }
       }
       .frame(height: 60)

--- a/ios/HackerNews/Feed/FeedScreen.swift
+++ b/ios/HackerNews/Feed/FeedScreen.swift
@@ -23,6 +23,7 @@ struct FeedScreen: View {
           .containerShape(.rect(cornerRadius: 24, style: .continuous))
 
         HStack(spacing: 16) {
+          Spacer()
           ForEach(model.feedState.feeds, id: \.self) { feedType in
             Button(action: {
               withAnimation {
@@ -37,7 +38,9 @@ struct FeedScreen: View {
                 .foregroundColor(
                   model.feedState.selectedFeed == feedType ? .hnOrange : .gray)
             }
+            .frame(maxWidth: .infinity)
           }
+          Spacer()
         }
       }
       .frame(height: 60)


### PR DESCRIPTION
This is to better accommodate weird spacing issues with 85% text size on specific devices. 

Before:
![IMG_4185](https://github.com/user-attachments/assets/69191e73-38a3-49a8-8bf2-9c1fbaf0f14c)


After:
![simulator_screenshot_EF8C8C42-AD10-43FC-A3A0-DC65D5D75289](https://github.com/user-attachments/assets/a45802ca-4aee-406f-9221-fdd2d12072e7)
