### PR TITLE
Add share button to Web View menu

### DIFF
--- a/ios/HackerNews/Web/WebView.swift
+++ b/ios/HackerNews/Web/WebView.swift
@@ -47,9 +47,14 @@ struct WebViewContainer: View {
             } label: {
               Label("Open in browser", systemImage: "safari")
             }
-          } label: {
-            Image(systemName: "ellipsis")
+          ShareLink(item: self.model.url) {
+            Label("Share", systemImage: "square.and.arrow.up")
           }
+        } label: {
+          Image(systemName: "ellipsis")
+        }
+
+
         }
       }
   }


### PR DESCRIPTION
Allows user to share the link of the web view directly.