### PR TITLE
Consume snapshots from new url.

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
     mavenCentral()
     gradlePluginPortal()
     maven {
-      url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       mavenContent {
         includeGroupByRegex("com.emergetools.*")
         snapshotsOnly()
@@ -38,7 +38,7 @@ dependencyResolutionManagement {
 
     // We want to be able to use snapshots for the Emergetools SDK:
     maven {
-      url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       mavenContent {
         includeGroupByRegex("com.emergetools.*")
         snapshotsOnly()


### PR DESCRIPTION
Configuration copied from here: https://central.sonatype.org/publish/publish-portal-snapshots/#consuming-via-maven
