### PR TITLE
Bump sentry sdk version to latest

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,7 +132,7 @@ sentry {
 
   ignoredVariants.set(listOf("debug", "fast"))
 
-  autoInstallation.sentryVersion.set("8.12.0")
+  autoInstallation.sentryVersion.set("8.17.0")
 }
 
 dependencies {


### PR DESCRIPTION
This should get us logs via logcat https://docs.sentry.io/platforms/android/integrations/logcat/#support-with-sentry-logs