### PR TITLE
feat: update Sentry Fastlane plugin to latest version

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -169,7 +169,7 @@ platform :ios do
       project_slug: 'hackernews-ios',
       include_sources: true
     )
-    sentry_upload_mobile_app(
+    sentry_upload_build(
       auth_token: ENV['SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios'
@@ -186,7 +186,7 @@ platform :ios do
       app_id_suffix: ENV['APP_ID_SUFFIX']
     )
     thin_asset_catalogs
-    sentry_upload_mobile_app(
+    sentry_upload_build(
       auth_token: ENV['SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios'

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-emerge', '0.10.8'
-gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'c76fc6cba6c0db6dff958d79fbc8880a570da75e'
+gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'c57d6a1'


### PR DESCRIPTION
## Summary
- Update Sentry Fastlane plugin reference from commit c76fc6c to latest c57d6a1
- Replace deprecated `sentry_upload_mobile_app` action with `sentry_upload_build`
- Aligns with sentry-cli subcommand rename from `mobile-app` to `build`

🤖 Generated with [Claude Code](https://claude.ai/code)