### PR TITLE
Add VCSInfoExtension configuration to Sentry Android Gradle Plugin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -137,6 +137,15 @@ sentry {
   sizeAnalysis {
     enabled.set(true)
   }
+
+  vcsInfo {
+    System.getenv("GITHUB_HEAD_REF")?.let { headRef.set(it) }
+    System.getenv("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    headRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
+    baseRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
+    vcsProvider.set("github")
+    System.getenv("GITHUB_EVENT_NUMBER")?.toIntOrNull()?.let { prNumber.set(it) }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Add VCS information configuration for Sentry Android Gradle Plugin size analysis
- This just adds all the fields to test them. I'm not sure which ones are needed and which ones are optional.

🤖 Generated with [Claude Code](https://claude.ai/code)