### PR TITLE
Add base SHA configuration to VCSInfoExtension

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -141,6 +141,7 @@ sentry {
   vcsInfo {
     System.getenv("GITHUB_HEAD_REF")?.let { headRef.set(it) }
     System.getenv("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    System.getenv("GITHUB_EVENT_PULL_REQUEST_BASE_SHA")?.let { baseSha.set(it) }
     headRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     baseRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     vcsProvider.set("github")


### PR DESCRIPTION
## Summary
- Add baseSha configuration using GITHUB_EVENT_PULL_REQUEST_BASE_SHA environment variable
- Leave headSha unset to allow the plugin to auto-detect the current commit SHA
- Completes the VCS information setup for better size analysis comparisons

🤖 Generated with [Claude Code](https://claude.ai/code)