### PR TITLE
Enable Sentry debug flag for Android app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -142,7 +142,6 @@ sentry {
   vcsInfo {
     System.getenv("GITHUB_HEAD_REF")?.let { headRef.set(it) }
     System.getenv("GITHUB_BASE_REF")?.let { baseRef.set(it) }
-    System.getenv("GITHUB_EVENT_PULL_REQUEST_BASE_SHA")?.let { baseSha.set(it) }
     headRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     baseRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     vcsProvider.set("github")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -127,6 +127,7 @@ emerge {
 }
 
 sentry {
+  debug.set(true)
   org.set("emerge-tools")
   projectName.set("hackernews-android")
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -141,6 +141,7 @@ sentry {
   vcsInfo {
     System.getenv("GITHUB_HEAD_REF")?.let { headRef.set(it) }
     System.getenv("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    System.getenv("GITHUB_EVENT_PULL_REQUEST_BASE_SHA")?.let { baseSha.set(it) }
     headRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     baseRepoName.set(System.getenv("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews")
     vcsProvider.set("github")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -167,12 +167,14 @@ platform :ios do
       auth_token: ENV['SENTRY_AUTH_TOKEN'],
       org_slug: 'emerge-tools',
       project_slug: 'hackernews-ios',
-      include_sources: true
+      include_sources: true,
+      debug: true
     )
     sentry_upload_build(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
-      project_slug: 'launchpad-test-ios'
+      project_slug: 'launchpad-test-ios',
+      debug: true
     )
   end
 
@@ -189,7 +191,8 @@ platform :ios do
     sentry_upload_build(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
-      project_slug: 'launchpad-test-ios'
+      project_slug: 'launchpad-test-ios',
+      debug: true
     )
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -168,13 +168,13 @@ platform :ios do
       org_slug: 'emerge-tools',
       project_slug: 'hackernews-ios',
       include_sources: true,
-      debug: true
+      log_level: 'debug'
     )
     sentry_upload_build(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      debug: true
+      log_level: 'debug'
     )
   end
 
@@ -192,7 +192,7 @@ platform :ios do
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      debug: true
+      log_level: 'debug'
     )
   end
 


### PR DESCRIPTION
## Summary
• Enable debug logging for the Sentry Android Gradle Plugin

## Test plan
• Build the Android app and verify Sentry debug output appears in build logs

🤖 Generated with [Claude Code](https://claude.ai/code)