### PR TITLE
Enable Sentry debug logging for Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -138,6 +138,8 @@ sentry {
     enabled.set(true)
   }
 
+  debug.set(true)
+
   vcsInfo {
     (System.getenv("GITHUB_HEAD_REF") ?: System.getenv("GITHUB_REF"))?.let { headRef.set(it) }
     System.getenv("GITHUB_BASE_REF")?.let { baseRef.set(it) }


### PR DESCRIPTION
## Summary
Enable debug logging for the Android Sentry plugin by adding `debug.set(true)` to the sentry configuration.

This will provide more detailed logging output during the build process to help troubleshoot any issues with Sentry integration.

🤖 Generated with [Claude Code](https://claude.ai/code)