### PR TITLE
Add debug log_level to sentry_upload_build

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -179,7 +179,8 @@ platform :ios do
       head_ref: ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'],
       head_sha: ENV['GITHUB_SHA'],
       vcs_provider: 'github',
-      head_repo_name: 'emergetools/hackernews'
+      head_repo_name: 'emergetools/hackernews',
+      log_level: 'debug'
     )
   end
 
@@ -203,7 +204,8 @@ platform :ios do
       head_ref: ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'],
       head_sha: ENV['GITHUB_SHA'],
       vcs_provider: 'github',
-      head_repo_name: 'emergetools/hackernews'
+      head_repo_name: 'emergetools/hackernews',
+      log_level: 'debug'
     )
   end
 


### PR DESCRIPTION
## Summary
Add `log_level: 'debug'` to both `sentry_upload_build` calls in the iOS Fastfile to enable debug logging for better troubleshooting of Sentry build uploads.

🤖 Generated with [Claude Code](https://claude.ai/code)