### PR TITLE
Filter null/empty environment variables in iOS sentry_upload_build

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -18,6 +18,13 @@
 default_platform(:ios)
 
 platform :ios do
+  def sentry_upload_build_filtered(**params)
+    filtered_params = params.select { |key, value|
+      value && !value.to_s.strip.empty?
+    }
+    sentry_upload_build(**filtered_params)
+  end
+
   desc 'Load ASC API Key information to use in subsequent lanes'
   lane :load_asc_api_key do
     app_store_connect_api_key(
@@ -169,7 +176,7 @@ platform :ios do
       project_slug: 'hackernews-ios',
       include_sources: true
     )
-    sentry_upload_build(
+    sentry_upload_build_filtered(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
@@ -194,7 +201,7 @@ platform :ios do
       app_id_suffix: ENV['APP_ID_SUFFIX']
     )
     thin_asset_catalogs
-    sentry_upload_build(
+    sentry_upload_build_filtered(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',


### PR DESCRIPTION
## Summary
- Added `sentry_upload_build_filtered` helper method to filter out null or empty environment variables
- Updated both `build_upload_testflight` and `build_upload_emerge` lanes to use the filtered version
- Prevents passing empty/null values to sentry_upload_build which can cause issues

🤖 Generated with [Claude Code](https://claude.ai/code)