### PR TITLE
Add build_configuration to iOS sentry_upload_build calls

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -187,6 +187,7 @@ platform :ios do
       head_sha: ENV['SENTRY_SHA'],
       vcs_provider: 'github',
       head_repo_name: 'EmergeTools/hackernews',
+      build_configuration: 'Release',
       log_level: 'debug'
     )
   end
@@ -212,6 +213,7 @@ platform :ios do
       head_sha: ENV['SENTRY_SHA'],
       vcs_provider: 'github',
       head_repo_name: 'EmergeTools/hackernews',
+      build_configuration: ENV['CONFIGURATION'],
       log_level: 'debug'
     )
   end


### PR DESCRIPTION
## Summary
- Added `build_configuration` parameter to `sentry_upload_build_filtered` calls
- Matches the same build configuration pattern used for `build_app_for_scheme`:
  - `build_upload_testflight`: uses 'Release'
  - `build_upload_emerge`: uses `ENV['CONFIGURATION']`

This ensures the Sentry build upload uses the same build configuration as the corresponding app build in each lane.

🤖 Generated with [Claude Code](https://claude.ai/code)