### PR TITLE
Simplify setup of size analysis with alpha.2

### DIFF
--- a/.github/workflows/android_emerge_upload.yml
+++ b/.github/workflows/android_emerge_upload.yml
@@ -30,6 +30,5 @@ jobs:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           ANDROID_DISTRIBUTION_API_KEY: ${{ secrets.ANDROID_DISTRIBUTION_API_KEY}}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          GITHUB_PR_NUMBER: ${{ github.event.number }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SENTRY_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,7 +132,6 @@ sentry {
 
   ignoredVariants.set(listOf("debug", "fast"))
 
-  autoInstallation.sentryVersion.set(libs.versions.sentry.sdk.get())
 
   sizeAnalysis {
     enabled.set(true)
@@ -141,17 +140,7 @@ sentry {
   debug.set(true)
 
   vcsInfo {
-    fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
-
-    (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
-    env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
-    env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
-    env("SENTRY_SHA")?.let { headSha.set(it) }
-    val repoName = env("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews"
-    headRepoName.set(repoName)
-    baseRepoName.set(repoName)
     vcsProvider.set("github")
-    env("GITHUB_PR_NUMBER")?.toIntOrNull()?.let { prNumber.set(it) }
   }
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -143,6 +143,8 @@ sentry {
     fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
 
     (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
+    env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
     env("SENTRY_SHA")?.let { headSha.set(it) }
     vcsProvider.set("github")
   }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -142,6 +142,7 @@ sentry {
   vcsInfo {
     fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
 
+    (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
     env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
     env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
     env("SENTRY_SHA")?.let { headSha.set(it) }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -143,8 +143,6 @@ sentry {
     fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
 
     (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
-    env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
-    env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
     env("SENTRY_SHA")?.let { headSha.set(it) }
     vcsProvider.set("github")
   }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -140,6 +140,11 @@ sentry {
   debug.set(true)
 
   vcsInfo {
+    fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
+
+    env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
+    env("SENTRY_SHA")?.let { headSha.set(it) }
     vcsProvider.set("github")
   }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -146,6 +146,9 @@ sentry {
     env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
     env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
     env("SENTRY_SHA")?.let { headSha.set(it) }
+    val repoName = env("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews"
+    headRepoName.set(repoName)
+    baseRepoName.set(repoName)
     vcsProvider.set("github")
   }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ composeBom = "2025.09.00"
 uiTestJunit4Android = "1.9.0"
 uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.4.0"
-sentry-sdk = "8.17.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
I merged the update to Sentry Android Gradle Plugin from 6.0.0-alpha.1 to 6.0.0-alpha.2 with dependabot.
This is just the simplification of the setup.

🤖 Generated with [Claude Code](https://claude.ai/code)