### PR TITLE
Remove headSha setting from Sentry configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -145,7 +145,6 @@ sentry {
     (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
     env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
     env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
-    env("SENTRY_SHA")?.let { headSha.set(it) }
     val repoName = env("GITHUB_REPOSITORY") ?: "EmergeTools/hackernews"
     headRepoName.set(repoName)
     baseRepoName.set(repoName)


### PR DESCRIPTION
## Summary
- Remove the `headSha.set(it)` line from the Sentry vcsInfo configuration in the Android app build.gradle.kts

🤖 Generated with [Claude Code](https://claude.ai/code)