### PR TITLE
chore(ios): Update sentry-fastlane-plugin and simplify configuration

### DIFF
--- a/.github/workflows/ios_emerge_upload_adhoc.yml
+++ b/.github/workflows/ios_emerge_upload_adhoc.yml
@@ -57,6 +57,3 @@ jobs:
           WIDGET_PROV_PROFILE_NAME: HackerNews AdHoc HomeWidget
           ADHOC: true
           APP_ID_SUFFIX: adhoc
-          GITHUB_PR_NUMBER: ${{ github.event.number }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          SENTRY_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ios_emerge_upload_pr.yml
+++ b/.github/workflows/ios_emerge_upload_pr.yml
@@ -50,6 +50,3 @@ jobs:
           SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
           CONFIGURATION: Release
           EMERGE_BUILD_TYPE: pull-request
-          GITHUB_PR_NUMBER: ${{ github.event.number }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          SENTRY_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/getsentry/sentry-fastlane-plugin.git
-  revision: b0c36a1472a6bfde0a4766c612c1154706dbd014
-  ref: b0c36a1472a6bfde0a4766c612c1154706dbd014
+  revision: 840ac30316aeda41630db1be6c3d17d2c870d08c
+  ref: 840ac30316aeda41630db1be6c3d17d2c870d08c
   specs:
     fastlane-plugin-sentry (1.33.0)
       os (~> 1.1, >= 1.1.4)
@@ -231,6 +231,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -240,4 +241,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.3.26
+   2.7.2

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -180,13 +180,6 @@ platform :ios do
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      pr_number: ENV['GITHUB_PR_NUMBER'],
-      base_ref: ENV['GITHUB_BASE_REF'],
-      base_sha: ENV['GITHUB_BASE_SHA'],
-      head_ref: ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF']&.sub('refs/heads/', ''),
-      head_sha: ENV['SENTRY_SHA'],
-      vcs_provider: 'github',
-      head_repo_name: 'EmergeTools/hackernews',
       build_configuration: 'Release',
       log_level: 'debug'
     )
@@ -206,13 +199,6 @@ platform :ios do
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      pr_number: ENV['GITHUB_PR_NUMBER'],
-      base_ref: ENV['GITHUB_BASE_REF'],
-      base_sha: ENV['GITHUB_BASE_SHA'],
-      head_ref: ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF']&.sub('refs/heads/', ''),
-      head_sha: ENV['SENTRY_SHA'],
-      vcs_provider: 'github',
-      head_repo_name: 'EmergeTools/hackernews',
       build_configuration: ENV['CONFIGURATION'],
       log_level: 'debug'
     )

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-emerge', '0.10.8'
-gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'b0c36a1472a6bfde0a4766c612c1154706dbd014'
+gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: '840ac30316aeda41630db1be6c3d17d2c870d08c'


### PR DESCRIPTION
## Summary
- Update sentry-fastlane-plugin to 840ac30316aeda41630db1be6c3d17d2c870d08c
- Remove manual git metadata configuration (pr_number, base_ref, base_sha, head_ref, head_sha, vcs_provider, head_repo_name) from sentry_upload_build calls
- Remove corresponding environment variables from GitHub Actions workflows

The updated plugin now automatically handles git metadata detection, eliminating the need for manual configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)