### PR TITLE
chore(android): Enable Sentry size analysis only in CI

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -134,7 +134,7 @@ sentry {
 
 
   sizeAnalysis {
-    enabled.set(true)
+    enabled.set(providers.environmentVariable("GITHUB_ACTIONS").isPresent)
   }
 
   debug.set(true)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -134,7 +134,7 @@ sentry {
 
 
   sizeAnalysis {
-    enabled.set(providers.environmentVariable("GITHUB_ACTIONS").isPresent)
+    enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
   }
 
   debug.set(true)


### PR DESCRIPTION
## Summary
- Enables Sentry size analysis only when running in CI (GitHub Actions)
- This prevents size analysis from running in local development environments

This is what the gradle plugin will do in the future, but we have the gradle plugin hard coded to false right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)