### PR TITLE
chore(ios): Update sentry-fastlane-plugin to v1.34.0

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/getsentry/sentry-fastlane-plugin.git
-  revision: 840ac30316aeda41630db1be6c3d17d2c870d08c
-  ref: 840ac30316aeda41630db1be6c3d17d2c870d08c
-  specs:
-    fastlane-plugin-sentry (1.33.0)
-      os (~> 1.1, >= 1.1.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -124,6 +116,8 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-plugin-emerge (0.10.8)
       faraday (~> 1.1)
+    fastlane-plugin-sentry (1.34.0)
+      os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     gh_inspector (1.1.3)
@@ -237,7 +231,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-emerge (= 0.10.8)
-  fastlane-plugin-sentry!
+  fastlane-plugin-sentry (= 1.34.0)
   xcpretty
 
 BUNDLED WITH

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-emerge', '0.10.8'
-gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: '840ac30316aeda41630db1be6c3d17d2c870d08c'
+gem 'fastlane-plugin-sentry', '1.34.0'


### PR DESCRIPTION
## Summary
- Updates sentry-fastlane-plugin from v1.33.0 (git commit) to v1.34.0 (published gem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)