### PR TITLE
Remove fast and benchmark build types

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,16 +48,6 @@ android {
       isDebuggable = true
       applicationIdSuffix = ".debug"
     }
-    create("fast") {
-      isDebuggable = false
-      applicationIdSuffix = ".fast"
-      signingConfig = signingConfigs.getByName("debug")
-    }
-    create("benchmark") {
-      initWith(buildTypes.getByName("release"))
-      signingConfig = signingConfigs.getByName("debug")
-      matchingFallbacks += listOf("release")
-    }
     release {
       isDebuggable = false
       isMinifyEnabled = true
@@ -130,14 +120,14 @@ sentry {
   org.set("emerge-tools")
   projectName.set("hackernews-android")
 
-  ignoredVariants.set(listOf("debug", "fast"))
+  ignoredVariants.set(listOf("debug"))
 
 
   sizeAnalysis {
     enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
   }
 
-  debug.set(true)
+  debug = true
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Removed unused `fast` and `benchmark` build type configurations from the app module
- Updated Sentry `ignoredVariants` configuration to remove reference to `fast` build type

🤖 Generated with [Claude Code](https://claude.com/claude-code)