### PR TITLE
chore(ios): Disable debug log level for Sentry fastlane plugin

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -183,8 +183,7 @@ platform :ios do
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      build_configuration: 'Release',
-      log_level: 'debug'
+      build_configuration: 'Release'
     )
   end
 
@@ -202,8 +201,7 @@ platform :ios do
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'launchpad-test-ios',
-      build_configuration: ENV['CONFIGURATION'],
-      log_level: 'debug'
+      build_configuration: ENV['CONFIGURATION']
     )
   end
 


### PR DESCRIPTION
## Summary
- Removes `log_level: 'debug'` from Sentry upload build calls in both `build_upload_testflight` and `build_upload_emerge` lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)