### PR TITLE
chore(deps): Update fastlane-plugin-sentry to 1.35.0

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-plugin-emerge (0.10.8)
       faraday (~> 1.1)
-    fastlane-plugin-sentry (1.34.0)
+    fastlane-plugin-sentry (1.35.0)
       os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
@@ -231,7 +231,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-emerge (= 0.10.8)
-  fastlane-plugin-sentry (= 1.34.0)
+  fastlane-plugin-sentry (= 1.35.0)
   xcpretty
 
 BUNDLED WITH

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-emerge', '0.10.8'
-gem 'fastlane-plugin-sentry', '1.34.0'
+gem 'fastlane-plugin-sentry', '1.35.0'


### PR DESCRIPTION
## Summary
- Updated fastlane-plugin-sentry from 1.34.0 to 1.35.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)