### PR TITLE
ref(android): Standardize Sentry auth token to SENTRY_AUTH_TOKEN

### DIFF
--- a/.github/workflows/android_beta_build.yml
+++ b/.github/workflows/android_beta_build.yml
@@ -40,7 +40,7 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
-          SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
           SENTRY_DISTRIBUTION_AUTH_TOKEN: ${{ secrets.SENTRY_DISTRIBUTION_AUTH_TOKEN }}
         run: ./gradlew :app:assembleBeta
 

--- a/.github/workflows/android_emerge_snapshots.yml
+++ b/.github/workflows/android_emerge_snapshots.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew :app:bundleDebug :app:emergeUploadSnapshotBundleDebug
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
-          SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
 
   roborazzi:
     runs-on: ubuntu-latest

--- a/.github/workflows/android_emerge_upload.yml
+++ b/.github/workflows/android_emerge_upload.yml
@@ -28,6 +28,6 @@ jobs:
         run: ./gradlew :app:bundleRelease :app:emergeUploadReleaseAab
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
-          SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SENTRY_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/android_release_build.yml
+++ b/.github/workflows/android_release_build.yml
@@ -44,7 +44,7 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
-          SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
         run: ./gradlew :app:bundlePlayStoreRelease
 
       - name: Convert AAB to APK

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -113,7 +113,6 @@ emerge {
 
 sentry {
   org.set("sentry")
-  authToken = providers.environmentVariable("SENTRY_SENTRY_AUTH_TOKEN")
   projectName.set("launchpad-test-android")
 
   ignoredVariants.set(listOf("debug"))


### PR DESCRIPTION
## Summary
- Updated all Android workflows to use `SENTRY_AUTH_TOKEN` environment variable
- Removed explicit `authToken` configuration from `android/app/build.gradle.kts`
- The Sentry Gradle plugin automatically picks up `SENTRY_AUTH_TOKEN` from the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)