### PR TITLE
chore(android): Bump version to 1.0.4

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
     applicationId = "com.emergetools.hackernews"
     minSdk = 30
     targetSdk = 36
-    versionCode = 14
-    versionName = "1.0.3"
+    versionCode = 15
+    versionName = "1.0.4"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables {


### PR DESCRIPTION
## Summary
- Increment versionCode from 14 to 15
- Increment versionName from 1.0.3 to 1.0.4

Preparing for the next Android release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

FOR EXAMPLE ONLY:

See this PR in Sentry [PR #653](https://sentry.sentry.io/pull/EmergeTools/hackernews/653/?tab=files) ([Size analysis](https://sentry.sentry.io/pull/EmergeTools/hackernews/653/?tab=size_analysis) | Codecov)