### PR TITLE
chore(android): Bump Sentry Java SDK to 8.26.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -117,7 +117,7 @@ sentry {
 
   ignoredVariants.set(listOf("debug"))
 
-  autoInstallation.sentryVersion = "8.24.0"
+  autoInstallation.sentryVersion = "8.26.0"
 
   sizeAnalysis {
     enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent


### PR DESCRIPTION
## Summary
- Updated Sentry Java SDK from 8.24.0 to 8.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)