### PR TITLE
fix(ci): Set GITHUB_HEAD_REF in release workflow to fix Sentry upload

### DIFF
--- a/.github/workflows/android_release_build.yml
+++ b/.github/workflows/android_release_build.yml
@@ -45,6 +45,8 @@ jobs:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          # Hack to ensure head-ref is set to avoid failing uploading to Sentry
+          GITHUB_HEAD_REF: release
         run: ./gradlew :app:bundlePlayStoreRelease
 
       - name: Convert AAB to APK


### PR DESCRIPTION
## Summary
Sets `GITHUB_HEAD_REF` environment variable to `release` in the Android release build workflow to prevent Sentry upload failures.

The release workflow is triggered by the `release` event which doesn't automatically set `GITHUB_HEAD_REF`. This causes the Sentry SDK to fail when uploading release artifacts. By explicitly setting this variable, the upload process completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)