### PR TITLE
fix(ci): Configure Sentry headRef in build config instead of workflow

### DIFF
--- a/.github/workflows/android_release_build.yml
+++ b/.github/workflows/android_release_build.yml
@@ -45,8 +45,6 @@ jobs:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
-          # Hack to ensure head-ref is set to avoid failing uploading to Sentry
-          GITHUB_HEAD_REF: release
         run: ./gradlew :app:bundlePlayStoreRelease
 
       - name: Convert AAB to APK

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -128,6 +128,14 @@ sentry {
     updateSdkVariants.add("beta")
   }
 
+  vcsInfo {
+    // Set headRef to "release" when running in GitHub release workflow
+    val eventName = providers.environmentVariable("GITHUB_EVENT_NAME").orNull
+    if (eventName == "release") {
+      headRef.set("release")
+    }
+  }
+
   debug = true
 }
 


### PR DESCRIPTION
## Summary
- Remove `GITHUB_HEAD_REF` environment variable hack from the Android release workflow
- Configure Sentry Gradle plugin's `vcsInfo.headRef` parameter to detect release workflows using `GITHUB_EVENT_NAME`

This moves the configuration from the workflow to the proper location in the build configuration, making it more maintainable and following the intended plugin architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)