### PR TITLE
fix(ci): Restore Sentry vcsInfo configuration for release workflow

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -126,6 +126,14 @@ sentry {
     updateSdkVariants.add("beta")
   }
 
+  vcsInfo {
+    // Set headRef to "release" when running in GitHub release workflow
+    val eventName = providers.environmentVariable("GITHUB_EVENT_NAME").orNull
+    if (eventName == "release") {
+      headRef.set("release")
+    }
+  }
+
   debug = true
 }
 


### PR DESCRIPTION
## Summary
- Re-add the `vcsInfo` block to the Sentry Gradle configuration to properly set the headRef to "release" when running in GitHub release workflows
- This ensures correct commit association in Sentry's release tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)