### PR TITLE
chore(android): Update Sentry configuration for hackernews-android project

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -113,7 +113,7 @@ emerge {
 
 sentry {
   org.set("sentry")
-  projectName.set("launchpad-test-android")
+  projectName.set("hackernews-android")
 
   ignoredVariants.set(listOf("debug"))
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
 
         <meta-data
             android:name="io.sentry.dsn"
-            android:value="https://db2524adf3fee320562f372d15f98098@o497846.ingest.us.sentry.io/4506028523388928" />
+            android:value="https://d381e3d533c65c895caaa6e084940537@o1.ingest.us.sentry.io/4510398352719872" />
 
         <!-- add breadcrumbs for user interactions (clicks, swipes, scrolls) -->
         <meta-data


### PR DESCRIPTION
## Summary
- Updated Android Sentry DSN to new hackernews-android project
- Changed Sentry project name from launchpad-test-android to hackernews-android

🤖 Generated with [Claude Code](https://claude.com/claude-code)