### PR TITLE
chore(android): Bump version to 1.0.6

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
     applicationId = "com.emergetools.hackernews"
     minSdk = 30
     targetSdk = 36
-    versionCode = 16
-    versionName = "1.0.5"
+    versionCode = 17
+    versionName = "1.0.6"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables {


### PR DESCRIPTION
## Summary
- Updates Android versionCode from 16 to 17
- Updates Android versionName from 1.0.5 to 1.0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)