### PR TITLE
chore(android): Enable Sentry distribution upload

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -117,8 +117,8 @@ sentry {
   }
 
   distribution {
-    //enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
-    //updateSdkVariants.add("beta")
+    enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
+    updateSdkVariants.add("beta")
   }
 
   vcsInfo {


### PR DESCRIPTION
## Summary
- Re-enabled Sentry distribution upload in GitHub Actions
- Uncommented the distribution configuration in build.gradle.kts

🤖 Generated with [Claude Code](https://claude.com/claude-code)