### PR TITLE
refactor(sentry): Remove vcsInfo configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -121,14 +121,6 @@ sentry {
     updateSdkVariants.add("beta")
   }
 
-  vcsInfo {
-    // Set headRef to "release" when running in GitHub release workflow
-    val eventName = providers.environmentVariable("GITHUB_EVENT_NAME").orNull
-    if (eventName == "release") {
-      headRef.set("release")
-    }
-  }
-
   debug = true
 }
 


### PR DESCRIPTION
## Summary
- Removes unnecessary vcsInfo configuration block since this was fixed in https://github.com/getsentry/sentry-cli/releases/tag/2.58.3
