### PR TITLE
chore(ci): Remove unused REAPER_API_KEY from workflows

### DIFF
--- a/.github/workflows/android_beta_build.yml
+++ b/.github/workflows/android_beta_build.yml
@@ -39,7 +39,6 @@ jobs:
           RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
-          REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
           SENTRY_DISTRIBUTION_AUTH_TOKEN: ${{ secrets.SENTRY_DISTRIBUTION_AUTH_TOKEN }}
         run: ./gradlew :app:assembleBeta

--- a/.github/workflows/android_release_build.yml
+++ b/.github/workflows/android_release_build.yml
@@ -43,7 +43,6 @@ jobs:
           RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
-          REAPER_API_KEY: ${{ secrets.REAPER_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
         run: ./gradlew :app:bundlePlayStoreRelease
 


### PR DESCRIPTION
Remove unused `REAPER_API_KEY` environment variable