### PR TITLE
chore(android): Migrate to Kotlin 2.3.0 and modern compiler options

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import jdk.jfr.internal.JVM
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -70,9 +73,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
-  }
   packaging {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -88,6 +88,11 @@ android {
   }
 }
 
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
+  }
+}
 ksp {
   arg("room.generateKotlin", "true")
 }

--- a/android/benchmark/build.gradle.kts
+++ b/android/benchmark/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.test)
   alias(libs.plugins.kotlin.android)
@@ -28,12 +30,15 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
-  }
 
   targetProjectPath = ":app"
   experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
+  }
 }
 
 dependencies {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 ksp = "2.3.4"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary
- Updates Kotlin from 2.2.21 to 2.3.0
- Migrates from deprecated `kotlinOptions.jvmTarget` to `kotlin.compilerOptions.jvmTarget`
- Uses `JvmTarget` enum instead of string-based version specification
- Applied to both app and benchmark modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)