### PR TITLE
chore(ci): Remove unused GITHUB_BASE_SHA and SENTRY_SHA env variables

### DIFF
--- a/.github/workflows/android_emerge_upload.yml
+++ b/.github/workflows/android_emerge_upload.yml
@@ -29,5 +29,3 @@ jobs:
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          SENTRY_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary
- Removed `GITHUB_BASE_SHA` and `SENTRY_SHA` environment variables from the Android Emerge workflow as they are no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)