### PR TITLE
chore(ios): Update sentry-fastlane-plugin to 2.1.0

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-plugin-emerge (0.10.8)
       faraday (~> 1.1)
-    fastlane-plugin-sentry (1.35.0)
+    fastlane-plugin-sentry (2.1.0)
       os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
@@ -235,7 +235,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-emerge (= 0.10.8)
-  fastlane-plugin-sentry (= 1.35.0)
+  fastlane-plugin-sentry (= 2.1.0)
   xcpretty
 
 BUNDLED WITH

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-emerge', '0.10.8'
-gem 'fastlane-plugin-sentry', '1.36.0'
+gem 'fastlane-plugin-sentry', '2.1.0'


### PR DESCRIPTION
## Summary
- Updated sentry-fastlane-plugin from 1.35.0 to 2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)