### PR TITLE
Remove Paparazzi task from snapshot workflow

### DIFF
--- a/.github/workflows/android_emerge_snapshots.yml
+++ b/.github/workflows/android_emerge_snapshots.yml
@@ -39,7 +39,7 @@ jobs:
         run: gem install emerge
 
       - name: Generate Paparazzi snapshots
-        run: ./gradlew :app:recordPaparazziDebug :app:sentryUploadSnapshotsDebug
+        run: ./gradlew :app:sentryUploadSnapshotsDebug
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -126,7 +126,7 @@ sentry {
 
   snapshots {
     enabled = true
-    includePrivatePreviews = true
+
     theme = "android:Theme.Transluscent.NoTitleBar"
   }
 


### PR DESCRIPTION
## Summary
- Remove `recordPaparazziDebug` Gradle task from the snapshot CI workflow since Sentry's plugin handles snapshot generation via previews directly
- Remove `includePrivatePreviews = true` from the Sentry snapshots config

🤖 Generated with [Claude Code](https://claude.com/claude-code)