### PR TITLE
ref(ios): Remove .previewDevice and duplicate preview variants

### DIFF
--- a/ios/HackerNews/Utils/Previews.swift
+++ b/ios/HackerNews/Utils/Previews.swift
@@ -23,49 +23,18 @@ struct PreviewVariants<Content: View>: View {
         .environment(\.colorScheme, .light)
         .preferredColorScheme(.light)
         .navigationBarHidden(true)
-        .previewDevice("iPhone 11 Pro Max")
-        .previewDisplayName("iPhone 11 Pro Max, light mode")
+        .previewDisplayName("Light mode")
 
       self.content
         .environment(\.colorScheme, .dark)
         .preferredColorScheme(.dark)
         .navigationBarHidden(true)
-        .previewDevice("iPhone 11 Pro Max")
-        .previewDisplayName("iPhone 11 Pro Max, dark mode")
+        .previewDisplayName("Dark mode")
 
       self.content
         .environment(\.colorScheme, .light)
         .preferredColorScheme(.light)
         .navigationBarHidden(true)
-        .previewDevice("iPhone 8")
-        .previewDisplayName("iPhone 8, light mode")
-
-      self.content
-        .environment(\.colorScheme, .dark)
-        .preferredColorScheme(.dark)
-        .navigationBarHidden(true)
-        .previewDevice("iPhone 8")
-        .previewDisplayName("iPhone 8, dark mode")
-
-      self.content
-        .environment(\.colorScheme, .light)
-        .preferredColorScheme(.light)
-        .navigationBarHidden(true)
-        .previewDevice("iPad Air (5th generation)")
-        .previewDisplayName("iPad Air, light mode")
-
-      self.content
-        .environment(\.colorScheme, .dark)
-        .preferredColorScheme(.dark)
-        .navigationBarHidden(true)
-        .previewDevice("iPad Air (5th generation)")
-        .previewDisplayName("iPad Air, dark mode")
-
-      self.content
-        .environment(\.colorScheme, .light)
-        .preferredColorScheme(.light)
-        .navigationBarHidden(true)
-        .previewDevice("iPhone 11 Pro Max")
         .previewDisplayName("Accessibility")
         .emergeAccessibility(true)
     }


### PR DESCRIPTION
Remove all `.previewDevice(...)` modifiers from `PreviewVariants` in `ios/HackerNews/Utils/Previews.swift`.

With the device modifier gone, the per-device variants (iPhone 11 Pro Max, iPhone 8, iPad Air) rendered on the same default device and produced identical output. The six color-scheme × device entries collapse into three meaningful cases: light mode, dark mode, and accessibility.