### PR TITLE
fix(ios): Pin SnapshotPreviews

### DIFF
--- a/ios/HackerNews.xcodeproj/project.pbxproj
+++ b/ios/HackerNews.xcodeproj/project.pbxproj
@@ -1271,8 +1271,9 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = versionRange;
+				maximumVersion = 1.0.0;
+				minimumVersion = 0.13.0;
 			};
 		};
 		F48E9EC92D4D691600FD8B30 /* XCRemoteSwiftPackageReference "ETDistribution" */ = {

--- a/ios/HackerNews.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/HackerNews.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/EmergeTools/SnapshotPreviews",
       "state" : {
-        "branch" : "main",
-        "revision" : "ee693c3b7d74ad237b82ad3cd4a6394dda4b6667"
+        "revision" : "83131a5d354b68b48f57f6866d0b4ef3701e1c43",
+        "version" : "0.13.0"
       }
     },
     {


### PR DESCRIPTION
Pin the `SnapshotPreviews` Swift package dependency to the semantic version range `0.13.0..<1.0.0` instead of tracking the upstream `main` branch.

Tracking `main` meant each resolve could pull in unreviewed upstream changes, making builds non-reproducible and leaving snapshot tests vulnerable to breakage from dependency drift. Pinning to a version range keeps future updates explicit and reviewable while still allowing non-breaking upgrades within the 0.x line.

Resolved revision moves from `ee693c3` (unversioned `main`) to `83131a5` (tag `0.13.0`).