### PR TITLE
test(ios): Set diffThreshold to 0.002 on CommentsScreen preview

### DIFF
--- a/ios/HackerNews/Comments/CommentsScreen.swift
+++ b/ios/HackerNews/Comments/CommentsScreen.swift
@@ -149,6 +149,7 @@ struct StoryScreen_Preview: PreviewProvider {
       PreviewHelpers.withNavigationView {
         CommentsScreen(model: viewModel)
           .environment(Theme())
+          .diffThreshold(0.002)
       }
     }
   }


### PR DESCRIPTION
Tighten the snapshot diff tolerance for the `StoryScreen_Preview` in
`CommentsScreen.swift` by setting `.diffThreshold(0.002)` on the preview.

The repo recently adopted SnapshotPreviews + SwiftSnapshotTesting for
uploading previews as snapshots to Sentry (#780). The library's default
diff threshold is lenient enough that small rendering regressions in
the comments screen can slip through unnoticed. 0.002 matches a tight
tolerance while still tolerating sub-pixel antialiasing noise.

This is intentionally a one-preview change so we can observe how the
tighter threshold behaves against the existing baseline before rolling
it out more broadly to other previews.