### PR TITLE
Update Sentry Android Gradle Plugin to 6.6.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -127,7 +127,9 @@ sentry {
   snapshots {
     enabled = true
 
-    theme = "android:Theme.Transluscent.NoTitleBar"
+    previews {
+      theme = "android:Theme.Transluscent.NoTitleBar"
+    }
   }
 
   debug = true
@@ -153,6 +155,7 @@ dependencies {
   implementation(libs.extendedspans)
 
   implementation(libs.emerge.snapshots.runtime)
+  implementation(libs.sentry.snapshots.runtime)
   implementation(libs.okhttp)
   implementation(libs.retrofit)
   implementation(libs.retrofit.kotlinx.serialization)

--- a/android/app/src/main/java/com/emergetools/hackernews/ui/components/MetadataTag.kt
+++ b/android/app/src/main/java/com/emergetools/hackernews/ui/components/MetadataTag.kt
@@ -25,6 +25,7 @@ import com.emergetools.hackernews.R
 import com.emergetools.hackernews.ui.theme.HackerBlue
 import com.emergetools.hackernews.ui.theme.HackerGreen
 import com.emergetools.hackernews.ui.theme.HackerNewsTheme
+import io.sentry.snapshots.runtime.SentrySnapshot
 
 @Composable
 fun MetadataTag(
@@ -47,6 +48,7 @@ fun MetadataTag(
   }
 }
 
+@SentrySnapshot(diffThreshold = 0.1f)
 @PreviewLightDark
 @Composable
 fun MetadataTagPreview() {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ viewmodel = "2.10.0"
 navigation = "2.9.7"
 browser = "1.10.0"
 emergePlugin = "4.4.0"
-sentry = "6.5.0"
+sentry = "6.6.0"
 shapes = "1.1.0"
 datastore = "1.2.1"
 room = "2.8.4"
@@ -59,6 +59,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 emerge-snapshots-runtime = { group = "com.emergetools.snapshots", name = "snapshots-runtime", version = "1.5.1" }
+sentry-snapshots-runtime = { group = "io.sentry", name = "sentry-snapshots-runtime", version.ref = "sentry" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Summary
- Bump SAGP from 6.5.0 to 6.6.0
- Migrate `theme` from `snapshots {}` into the new nested `previews {}` block (breaking DSL change in 6.6.0)
- Add `sentry-snapshots-runtime` dependency and annotate `MetadataTagPreview` with `@SentrySnapshot(diffThreshold = 0.1f)`

diffThreshold correctly appears in the metadata: 
<img width="461" height="339" alt="Screenshot 2026-05-04 at 13 26 18" src="https://github.com/user-attachments/assets/6e7f3981-b907-4f54-8a81-446b49ef3fc5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)