### PR TITLE
fix(ios): Export thinned IPA for size analysis

### DIFF
--- a/.github/workflows/ios_sentry_upload_pr.yml
+++ b/.github/workflows/ios_sentry_upload_pr.yml
@@ -44,4 +44,5 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.IOS_DIST_SIGNING_KEY_PASSWORD }}
           SIGNING_KEY_FILE_PATH: signing-cert.p12
           SENTRY_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CONFIGURATION: Release

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -101,7 +101,7 @@ platform :ios do
     profile_name = ENV['PROV_PROFILE_NAME'] || 'Github'
     widget_profile_name = ENV['WIDGET_PROV_PROFILE_NAME'] || 'HackerNewsHomeWidget Distribution'
     output_name = 'hackernews-iOS' # .ipa name
-    export_method = 'app-store'
+    export_method = 'app-store-connect'
 
     # Turn off automatic signing during build so correct code signing identity is guaranteed to be used
     update_code_signing_settings(
@@ -139,7 +139,7 @@ platform :ios do
           bundle_identifier => profile_name,
           'com.emergetools.hackernews.HackerNewsHomeWidget' => widget_profile_name
         },
-        team_id: ENV['APPLE_TEAM_ID']
+        teamID: ENV['APPLE_TEAM_ID']
       }
     )
   end
@@ -210,13 +210,14 @@ platform :ios do
 
     app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
     bundle_identifier = ENV['BUNDLE_ID'] || app_identifier
-    profile_name = ENV['PROV_PROFILE_NAME'] || 'Github'
-    widget_profile_name = ENV['WIDGET_PROV_PROFILE_NAME'] || 'HackerNewsHomeWidget Distribution'
+    profile_name = ENV['PROV_PROFILE_NAME'] || 'HackerNews AdHoc Distribution'
+    widget_profile_name = ENV['WIDGET_PROV_PROFILE_NAME'] || 'HackerNews AdHoc HomeWidget'
 
     export_options = {
-      method: 'app-store',
+      method: 'release-testing',
       thinning: device_type,
-      team_id: ENV['APPLE_TEAM_ID'],
+      teamID: ENV['APPLE_TEAM_ID'],
+      signingStyle: 'manual',
       provisioningProfiles: {
         bundle_identifier => profile_name,
         'com.emergetools.hackernews.HackerNewsHomeWidget' => widget_profile_name
@@ -240,26 +241,24 @@ platform :ios do
     )
 
     thinning_plist_path = File.join(export_dir, 'app-thinning.plist')
+    UI.user_error!("App thinning report not found in #{export_dir}") unless File.file?(thinning_plist_path)
+
+    plist_data = Plist.parse_xml(thinning_plist_path)
     ipa_path = nil
+    plist_data&.fetch('variants', {})&.each do |path, variant|
+      descriptors = variant['variantDescriptors'] || []
+      next unless descriptors.any? { |descriptor| descriptor['device'] == device_type }
 
-    if File.exist?(thinning_plist_path)
-      plist_data = Plist.parse_xml(thinning_plist_path)
-      plist_data&.fetch('variants', {})&.each do |path, variant|
-        descriptors = variant['variantDescriptors'] || []
-        next unless descriptors.any? { |descriptor| descriptor['device'] == device_type }
-
-        candidates = [
-          path,
-          File.join(export_dir, path),
-          File.expand_path(path, export_dir)
-        ]
-        ipa_path = candidates.find { |candidate| File.file?(candidate) }
-        break if ipa_path
-      end
+      candidates = [
+        path,
+        File.join(export_dir, path),
+        File.expand_path(path, export_dir)
+      ]
+      ipa_path = candidates.find { |candidate| File.file?(candidate) }
+      break if ipa_path
     end
 
-    ipa_path ||= Dir.glob(File.join(export_dir, '**', '*.ipa')).first
-    UI.user_error!("No thinned IPA found in #{export_dir}") unless ipa_path
+    UI.user_error!("No thinned IPA found for #{device_type} in #{export_dir}") unless ipa_path
 
     UI.message("Using thinned IPA for Sentry Size Analysis: #{ipa_path}")
     ipa_path


### PR DESCRIPTION
The iOS PR Size Analysis workflow now creates a `release-testing` export with the ad hoc profiles and uploads only the IPA explicitly identified as the requested device variant. The normal archive remains an App Store Connect export, and the workflow passes the Apple team ID explicitly.

Previously, the lane requested thinning during an App Store export, where Xcode ignores the option, then fell back to the first IPA it found. The export now requires `app-thinning.plist` and the requested device descriptor, so it fails instead of silently uploading a universal IPA.

Here's an earlier "release" build prior to this change vs after the change in the Sentry UI. You can see the duplicate asset catalog images are now "thinned" in builds we upload for size analysis:

| Before | After |
| --- | --- |
|<img width="1654" height="791" alt="before-thin" src="https://github.com/user-attachments/assets/3ae94df0-e867-4985-bd4d-16d64ff9c415" />|<img width="1649" height="814" alt="after-thin" src="https://github.com/user-attachments/assets/0cbc5026-f156-4780-80b4-e996d2bde81d" />|

Refs [EME-1285](https://linear.app/getsentry/issue/EME-1285/investigate-app-thinning-docs-discrepancy-thinning-key-is-ignored-for)
