### PR TITLE
test(ios): Exercise bundled dSYM build upload

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/getsentry/sentry-fastlane-plugin.git
+  revision: 85947a7410f5a31f3e9b2e3670861309d0ca989d
+  branch: codex/ipa-dsym-build-upload-3.7.0
+  specs:
+    fastlane-plugin-sentry (2.6.3)
+      os (~> 1.1, >= 1.1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -123,8 +131,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-sentry (2.5.2)
-      os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.102.0)
@@ -242,7 +248,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
-  fastlane-plugin-sentry (>= 2.5.1, < 3.0.0)
+  fastlane-plugin-sentry (>= 2.5.1, < 3.0.0)!
   xcpretty
 
 BUNDLED WITH

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -186,17 +186,19 @@ platform :ios do
     prepare_signing
     build_app_for_scheme
     ipa_path = export_thinned_size_analysis_ipa
-    xcarchive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE]
-    replace_xcarchive_app_with_ipa(
-      ipa_path: ipa_path,
-      xcarchive_path: xcarchive_path
+    xcarchive_path = File.expand_path(
+      lane_context[SharedValues::XCODEBUILD_ARCHIVE],
+      File.expand_path('..', __dir__)
     )
+    dsym_path = File.join(xcarchive_path, 'dSYMs')
+    UI.important("Testing IPA+dSYM upload with bundled sentry-cli: IPA=#{ipa_path}, dSYMs=#{dsym_path}")
     sentry_upload_build(
       auth_token: ENV['SENTRY_SENTRY_AUTH_TOKEN'],
       org_slug: 'sentry',
       project_slug: 'hackernews-ios',
-      xcarchive_path: xcarchive_path,
-      build_configuration: 'Release',
+      ipa_path: ipa_path,
+      dsym_path: dsym_path,
+      build_configuration: 'Release-dsym-e2e',
       log_level: 'debug'
     )
   end

--- a/ios/fastlane/Pluginfile
+++ b/ios/fastlane/Pluginfile
@@ -2,4 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-sentry', '>= 2.5.1', '< 3.0.0'
+gem 'fastlane-plugin-sentry', '>= 2.5.1', '< 3.0.0',
+    git: 'https://github.com/getsentry/sentry-fastlane-plugin.git',
+    branch: 'codex/ipa-dsym-build-upload-3.7.0'


### PR DESCRIPTION
Temporary integration test for getsentry/sentry-fastlane-plugin#531.

This pins the proposed Fastlane plugin branch and uploads the thinned IPA with the XCArchive dSYM directory using the plugin bundled sentry-cli 3.7.0 binary.